### PR TITLE
fix(README): documentation leads to user-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Documentation
 
 For detailed usage and installation instructions, check out
-the [documentation](https://bakdata.github.io/kpops/latest).
+the [documentation](https://bakdata.github.io/kpops/latest/user/what-is-kpops/).
 
 ## Install KPOps
 


### PR DESCRIPTION
[Home](https://bakdata.github.io/kpops/1.0/) page is currently empty and ugly. No need to have an extra step before reaching the [user guide](https://bakdata.github.io/kpops/1.0/user/what-is-kpops/).

To be reverted when [Home](https://bakdata.github.io/kpops/latest/) is improved enough.

Opens #164