### PR TITLE
Fix serialization of `pathlib.Path` type on model export

### DIFF
--- a/kpops/pipeline_generator/pipeline.py
+++ b/kpops/pipeline_generator/pipeline.py
@@ -234,8 +234,10 @@ class Pipeline:
 
     def __str__(self) -> str:
         return yaml.dump(
-            PipelineComponents(components=self.components).dict(
-                exclude_none=True, by_alias=True
+            json.loads(  # HACK: serialize types on Pydantic model export, which are not serialized by .dict(); e.g. pathlib.Path
+                PipelineComponents(components=self.components).json(
+                    exclude_none=True, by_alias=True
+                )
             )
         )
 

--- a/kpops/pipeline_generator/pipeline.py
+++ b/kpops/pipeline_generator/pipeline.py
@@ -200,7 +200,9 @@ class Pipeline:
     ) -> PipelineComponent:
         env_component_definition = self.env_components_index.get(component.name, {})
         pair = update_nested_pair(
-            env_component_definition, component.dict(by_alias=True)
+            env_component_definition,
+            # HACK: Pydantic .dict() doesn't create jsonable dict
+            json.loads(component.json(by_alias=True)),
         )
 
         component_data = self.substitute_component_specific_variables(component, pair)

--- a/tests/pipeline/resources/pipeline-with-paths/pipeline.yaml
+++ b/tests/pipeline/resources/pipeline-with-paths/pipeline.yaml
@@ -1,0 +1,14 @@
+- type: producer
+  name: account-producer
+  namespace: test
+  app:
+    streams:
+      brokers: test
+      output_topic: out
+  repo_config:
+    repository_name: masked
+    url: masked
+    repo_auth_flags:
+      username: masked
+      password: $CI_JOB_TOKEN
+      ca_file: /my-cert.cert

--- a/tests/pipeline/snapshots/snap_test_pipeline.py
+++ b/tests/pipeline/snapshots/snap_test_pipeline.py
@@ -542,6 +542,37 @@ snapshots["TestPipeline.test_load_pipeline test-pipeline"] = {
     ]
 }
 
+snapshots["TestPipeline.test_model_serialization test-pipeline"] = {
+    "components": [
+        {
+            "app": {
+                "nameOverride": "resources-pipeline-with-paths-account-producer",
+                "streams": {
+                    "brokers": "test",
+                    "extraOutputTopics": {},
+                    "outputTopic": "out",
+                    "schemaRegistryUrl": "http://localhost:8081",
+                },
+            },
+            "name": "resources-pipeline-with-paths-account-producer",
+            "namespace": "test",
+            "prefix": "resources-pipeline-with-paths-",
+            "repoConfig": {
+                "repoAuthFlags": {
+                    "caFile": "/my-cert.cert",
+                    "insecureSkipTlsVerify": False,
+                    "password": "$CI_JOB_TOKEN",
+                    "username": "masked",
+                },
+                "repositoryName": "masked",
+                "url": "masked",
+            },
+            "type": "producer",
+            "version": "2.4.2",
+        }
+    ]
+}
+
 snapshots["TestPipeline.test_no_input_topic test-pipeline"] = {
     "components": [
         {

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -309,3 +309,23 @@ class TestPipeline:
         assert error_topic == "resources-custom-config-app2-error"
 
         snapshot.assert_match(enriched_pipeline, "test-pipeline")
+
+    def test_model_serialization(self, snapshot: SnapshotTest):
+        """Component containing pathlib.Path attribute"""
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--pipeline-base-dir",
+                PIPELINE_BASE_DIR,
+                str(RESOURCE_PATH / "pipeline-with-paths/pipeline.yaml"),
+                "--defaults",
+                str(RESOURCE_PATH),
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+
+        enriched_pipeline = yaml.safe_load(result.stdout)
+        snapshot.assert_match(enriched_pipeline, "test-pipeline")

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -311,7 +311,7 @@ class TestPipeline:
         snapshot.assert_match(enriched_pipeline, "test-pipeline")
 
     def test_model_serialization(self, snapshot: SnapshotTest):
-        """Component containing pathlib.Path attribute"""
+        """Test model serialization of component containing pathlib.Path attribute"""
         result = runner.invoke(
             app,
             [


### PR DESCRIPTION
Fixes #167

Pydantic is currently lacking support for serializing types such as `pathlib.Path` when exporting models to `dict`. This requires an ugly workaround on our side. Support for this is planned with Pydantic v2, which introduces `model_dump(mode="json-compliant")` https://docs.pydantic.dev/blog/pydantic-v2/#improvements-to-dumpingserializationexport