### PR TITLE
Respect object docstring titles

### DIFF
--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -309,7 +309,7 @@
         },
         "KafkaApp": {
             "title": "KafkaApp",
-            "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+            "description": "Base component for Kafka-based components.\nProducer or streaming apps should inherit from this class.",
             "type": "object",
             "properties": {
                 "type": {
@@ -320,7 +320,7 @@
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+                    "description": "Base component for Kafka-based components.\nProducer or streaming apps should inherit from this class.",
                     "default": "kafka-app",
                     "enum": [
                         "kafka-app"
@@ -413,7 +413,7 @@
         },
         "KafkaConnector": {
             "title": "KafkaConnector",
-            "description": "Base class for all Kafka connectors Should only be used to set defaults",
+            "description": "Base class for all Kafka connectors\nShould only be used to set defaults",
             "type": "object",
             "properties": {
                 "type": {
@@ -424,7 +424,7 @@
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kafka connectors Should only be used to set defaults",
+                    "description": "Base class for all Kafka connectors\nShould only be used to set defaults",
                     "default": "kafka-connector",
                     "enum": [
                         "kafka-connector"
@@ -724,7 +724,7 @@
         },
         "KubernetesApp": {
             "title": "KubernetesApp",
-            "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+            "description": "Base class for all Kubernetes apps.\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
             "type": "object",
             "properties": {
                 "type": {
@@ -735,7 +735,7 @@
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+                    "description": "Base class for all Kubernetes apps.\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
                     "default": "kubernetes-app",
                     "enum": [
                         "kubernetes-app"
@@ -924,7 +924,7 @@
         },
         "ProducerApp": {
             "title": "ProducerApp",
-            "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+            "description": "Producer component\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
             "type": "object",
             "properties": {
                 "type": {
@@ -935,7 +935,7 @@
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+                    "description": "Producer component\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
                     "default": "producer",
                     "enum": [
                         "producer"
@@ -1168,7 +1168,7 @@
         },
         "StreamsAppConfig": {
             "title": "StreamsAppConfig",
-            "description": "StreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
+            "description": "StreamsBoostrap app configurations.\nThe attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
             "type": "object",
             "properties": {
                 "streams": {

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 from pydantic import BaseConfig, BaseModel, Extra
 from typing_extensions import override
 
-from kpops.utils.docstring import describe_class
+from kpops.utils.docstring import describe_object
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 
 
@@ -22,7 +22,7 @@ class KafkaConnectConfig(BaseModel):
         @override
         @staticmethod
         def schema_extra(schema: dict[str, Any], model: type[BaseModel]) -> None:  # type: ignore[override]
-            schema["description"] = describe_class(model.__doc__)
+            schema["description"] = describe_object(model.__doc__)
             schema["additionalProperties"] = {"type": "string"}
 
 

--- a/kpops/components/base_components/kafka_app.py
+++ b/kpops/components/base_components/kafka_app.py
@@ -16,7 +16,7 @@ from kpops.components.base_components.kubernetes_app import (
     KubernetesApp,
     KubernetesAppConfig,
 )
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 from kpops.utils.yaml_loading import substitute
 
@@ -82,7 +82,7 @@ class KafkaApp(KubernetesApp):
     schema_type: Literal["kafka-app"] = Field(  # type: ignore[assignment]
         default="kafka-app",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     app: KafkaAppConfig = Field(

--- a/kpops/components/base_components/kafka_connector.py
+++ b/kpops/components/base_components/kafka_connector.py
@@ -27,7 +27,7 @@ from kpops.components.base_components.base_defaults_component import deduplicate
 from kpops.components.base_components.models.from_section import FromTopic
 from kpops.components.base_components.pipeline_component import PipelineComponent
 from kpops.utils.colorify import magentaify
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.pydantic import CamelCaseConfig
 
 log = logging.getLogger("KafkaConnector")
@@ -62,7 +62,7 @@ class KafkaConnector(PipelineComponent, ABC):
     schema_type: Literal["kafka-connector"] = Field(  # type: ignore[assignment]
         default="kafka-connector",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     app: KafkaConnectConfig = Field(
@@ -330,7 +330,7 @@ class KafkaSourceConnector(KafkaConnector):
     schema_type: Literal["kafka-source-connector"] = Field(  # type: ignore[assignment]
         default="kafka-source-connector",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     offset_topic: str | None = Field(
@@ -401,7 +401,7 @@ class KafkaSinkConnector(KafkaConnector):
     schema_type: Literal["kafka-sink-connector"] = Field(  # type: ignore[assignment]
         default="kafka-sink-connector",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
 

--- a/kpops/components/base_components/kubernetes_app.py
+++ b/kpops/components/base_components/kubernetes_app.py
@@ -17,7 +17,7 @@ from kpops.component_handlers.helm_wrapper.model import (
 )
 from kpops.components.base_components.pipeline_component import PipelineComponent
 from kpops.utils.colorify import magentaify
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 
 log = logging.getLogger("KubernetesAppComponent")
@@ -63,7 +63,7 @@ class KubernetesApp(PipelineComponent):
     schema_type: Literal["kubernetes-app"] = Field(  # type: ignore[assignment]
         default="kubernetes-app",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     app: KubernetesAppConfig = Field(

--- a/kpops/components/base_components/pipeline_component.py
+++ b/kpops/components/base_components/pipeline_component.py
@@ -19,7 +19,7 @@ from kpops.components.base_components.models.to_section import (
     TopicConfig,
     ToSection,
 )
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 from kpops.utils.yaml_loading import substitute
 
@@ -51,7 +51,7 @@ class PipelineComponent(BaseDefaultsComponent):
     schema_type: Literal["pipeline-component"] = Field(  # type: ignore[assignment]
         default="pipeline-component",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     name: str = Field(default=..., description="Component name")

--- a/kpops/components/streams_bootstrap/producer/producer_app.py
+++ b/kpops/components/streams_bootstrap/producer/producer_app.py
@@ -12,7 +12,7 @@ from kpops.components.base_components.models.to_section import (
 )
 from kpops.components.streams_bootstrap.app_type import AppType
 from kpops.components.streams_bootstrap.producer.model import ProducerValues
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 
 
 class ProducerApp(KafkaApp):
@@ -36,7 +36,7 @@ class ProducerApp(KafkaApp):
     schema_type: Literal["producer"] = Field(  # type: ignore[assignment]
         default="producer",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     app: ProducerValues = Field(

--- a/kpops/components/streams_bootstrap/streams/model.py
+++ b/kpops/components/streams_bootstrap/streams/model.py
@@ -215,8 +215,7 @@ class StreamsAppAutoScaling(BaseModel):
 
 
 class StreamsAppConfig(KafkaAppConfig):
-    """
-    StreamsBoostrap app configurations.
+    """StreamsBoostrap app configurations.
 
     The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart.
 

--- a/kpops/components/streams_bootstrap/streams/streams_app.py
+++ b/kpops/components/streams_bootstrap/streams/streams_app.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 from kpops.components.base_components.kafka_app import KafkaApp
 from kpops.components.streams_bootstrap.app_type import AppType
 from kpops.components.streams_bootstrap.streams.model import StreamsAppConfig
-from kpops.utils.docstring import describe_attr, describe_class
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.pydantic import DescConfig
 
 
@@ -31,7 +31,7 @@ class StreamsApp(KafkaApp):
     schema_type: Literal["streams-app"] = Field(  # type: ignore[assignment]
         default="streams-app",
         title="Component type",
-        description=describe_class(__doc__),
+        description=describe_object(__doc__),
         exclude=True,
     )
     app: StreamsAppConfig = Field(

--- a/kpops/utils/docstring.py
+++ b/kpops/utils/docstring.py
@@ -22,7 +22,7 @@ def describe_attr(name: str, docstr: str | None) -> str:
 
 
 def describe_object(docstr: str | None) -> str:
-    """Return free-text description from a docstring
+    """Return description from an object's docstring
 
     Excludes parameters and return definitions
 
@@ -30,7 +30,7 @@ def describe_object(docstr: str | None) -> str:
 
     :param docstr: The docstring
     :type docstr: str, None
-    :returns: Description taken from the docstiirng
+    :returns: Description taken from the docstring
     :rtype: str
     """
     if docstr is None:
@@ -38,7 +38,8 @@ def describe_object(docstr: str | None) -> str:
 
     # reST docstrings have a short description/title as their first line.
     # Optionally, they have a longer description below. Here we separate the
-    # title from the rest as `_trim_description_end()` removes all newlines.
+    # title from the rest with a newline as `_trim_description_end()`
+    # removes all newlines.
     docstr = docstr.strip()
     if "\n" in docstr:
         title_end = docstr.index("\n")

--- a/kpops/utils/docstring.py
+++ b/kpops/utils/docstring.py
@@ -53,8 +53,9 @@ def _trim_description_end(desc: str) -> str:
     Also removes all whitespaces and newlines and replaces them with a single space.
 
     A description is defined here as a string of text written in natural language.
-    A description ends at the occurence of a separator such as `:returns:`.
-    Works only with reStructuredText docstrings.
+    A description ends at the occurence of a separator such as '\:returns\:'.
+
+    **Works only with reStructuredText docstrings.**
 
     :param desc: Description to be isolated, only the end will be trimmed
     :type desc: str

--- a/kpops/utils/docstring.py
+++ b/kpops/utils/docstring.py
@@ -21,29 +21,39 @@ def describe_attr(name: str, docstr: str | None) -> str:
     return _trim_description_end(docstr)
 
 
-def describe_class(docstr: str | None) -> str:
-    """Return class description from its docstring
+def describe_object(docstr: str | None) -> str:
+    """Return free-text description from a docstring
 
     Excludes parameters and return definitions
 
     Works only with reStructuredText docstrings.
 
-    :param docstr: The class' docstring
+    :param docstr: The docstring
     :type docstr: str, None
-    :returns: Class description taken from its docstiirng
+    :returns: Description taken from the docstiirng
     :rtype: str
     """
     if docstr is None:
         return ""
+
+    # reST docstrings have a short description/title as their first line.
+    # Optionally, they have a longer description below. Here we separate the
+    # title from the rest as `_trim_description_end()` removes all newlines.
+    docstr = docstr.strip()
+    if "\n" in docstr:
+        title_end = docstr.index("\n")
+        desc = docstr[:title_end] + "\n" + _trim_description_end(docstr[title_end:])
+        return desc.rstrip()
     return _trim_description_end(docstr)
 
 
 def _trim_description_end(desc: str) -> str:
     """Remove the unwanted text that comes after a description in a docstring
 
-    A description is defined here as a string of text written in natural language.
-    A description ends at the occurence of a separator such as `:returns:`
+    Also removes all whitespaces and newlines and replaces them with a single space.
 
+    A description is defined here as a string of text written in natural language.
+    A description ends at the occurence of a separator such as `:returns:`.
     Works only with reStructuredText docstrings.
 
     :param desc: Description to be isolated, only the end will be trimmed

--- a/kpops/utils/docstring.py
+++ b/kpops/utils/docstring.py
@@ -6,11 +6,11 @@ log = logging.getLogger("docstring_utils")
 def describe_attr(name: str, docstr: str | None) -> str:
     """Read attribute description from class docstring
 
-    Works only with reStructuredText docstrings.
+    **Works only with reStructuredText docstrings.**
 
     :param name: Attribute name
     :type name: str
-    :param docstr: Docstring from which to read. Note that the class' docstring is stored in attr `__doc__`
+    :param docstr: Docstring from which to read. Note that the class' docstring is stored in attr ``__doc__``
     :type docstr: str, None
     :returns: Description of the class attribute read from the class docstring
     :rtype: str
@@ -26,7 +26,7 @@ def describe_object(docstr: str | None) -> str:
 
     Excludes parameters and return definitions
 
-    Works only with reStructuredText docstrings.
+    **Works only with reStructuredText docstrings.**
 
     :param docstr: The docstring
     :type docstr: str, None
@@ -65,7 +65,7 @@ def _trim_description_end(desc: str) -> str:
     desc_enders = [
         ":param ",
         ":type ",
-        ":return:",
+        ":returns:",
         ":rtype:",
         "defaults to ",
     ]

--- a/kpops/utils/docstring.py
+++ b/kpops/utils/docstring.py
@@ -54,7 +54,7 @@ def _trim_description_end(desc: str) -> str:
     Also removes all whitespaces and newlines and replaces them with a single space.
 
     A description is defined here as a string of text written in natural language.
-    A description ends at the occurence of a separator such as '\:returns\:'.
+    A description ends at the occurence of a separator such as ``returns``.
 
     **Works only with reStructuredText docstrings.**
 

--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -3,7 +3,7 @@ from typing import Any
 import humps
 from pydantic import BaseConfig, BaseModel
 
-from kpops.utils.docstring import describe_class
+from kpops.utils.docstring import describe_object
 
 
 def to_camel(field: str) -> str:
@@ -20,4 +20,4 @@ class CamelCaseConfig(BaseConfig):
 class DescConfig(BaseConfig):
     @staticmethod
     def schema_extra(schema: dict[str, Any], model: type[BaseModel]) -> None:  # type: ignore[override]
-        schema["description"] = describe_class(model.__doc__)
+        schema["description"] = describe_object(model.__doc__)

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -561,7 +561,7 @@ snapshots[
         },
         "KafkaApp": {
             "title": "KafkaApp",
-            "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+            "description": "Base component for Kafka-based components.\\nProducer or streaming apps should inherit from this class.",
             "type": "object",
             "properties": {
                 "type": {
@@ -572,7 +572,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+                    "description": "Base component for Kafka-based components.\\nProducer or streaming apps should inherit from this class.",
                     "default": "kafka-app",
                     "enum": [
                         "kafka-app"
@@ -665,7 +665,7 @@ snapshots[
         },
         "KafkaConnector": {
             "title": "KafkaConnector",
-            "description": "Base class for all Kafka connectors Should only be used to set defaults",
+            "description": "Base class for all Kafka connectors\\nShould only be used to set defaults",
             "type": "object",
             "properties": {
                 "type": {
@@ -676,7 +676,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kafka connectors Should only be used to set defaults",
+                    "description": "Base class for all Kafka connectors\\nShould only be used to set defaults",
                     "default": "kafka-connector",
                     "enum": [
                         "kafka-connector"
@@ -976,7 +976,7 @@ snapshots[
         },
         "KubernetesApp": {
             "title": "KubernetesApp",
-            "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+            "description": "Base class for all Kubernetes apps.\\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
             "type": "object",
             "properties": {
                 "type": {
@@ -987,7 +987,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+                    "description": "Base class for all Kubernetes apps.\\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
                     "default": "kubernetes-app",
                     "enum": [
                         "kubernetes-app"
@@ -1176,7 +1176,7 @@ snapshots[
         },
         "ProducerApp": {
             "title": "ProducerApp",
-            "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+            "description": "Producer component\\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
             "type": "object",
             "properties": {
                 "type": {
@@ -1187,7 +1187,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+                    "description": "Producer component\\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
                     "default": "producer",
                     "enum": [
                         "producer"
@@ -1420,7 +1420,7 @@ snapshots[
         },
         "StreamsAppConfig": {
             "title": "StreamsAppConfig",
-            "description": "StreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
+            "description": "\\nStreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
             "type": "object",
             "properties": {
                 "streams": {
@@ -1963,7 +1963,7 @@ snapshots[
         },
         "KafkaApp": {
             "title": "KafkaApp",
-            "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+            "description": "Base component for Kafka-based components.\\nProducer or streaming apps should inherit from this class.",
             "type": "object",
             "properties": {
                 "type": {
@@ -1974,7 +1974,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base component for Kafka-based components. Producer or streaming apps should inherit from this class.",
+                    "description": "Base component for Kafka-based components.\\nProducer or streaming apps should inherit from this class.",
                     "default": "kafka-app",
                     "enum": [
                         "kafka-app"
@@ -2067,7 +2067,7 @@ snapshots[
         },
         "KafkaConnector": {
             "title": "KafkaConnector",
-            "description": "Base class for all Kafka connectors Should only be used to set defaults",
+            "description": "Base class for all Kafka connectors\\nShould only be used to set defaults",
             "type": "object",
             "properties": {
                 "type": {
@@ -2078,7 +2078,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kafka connectors Should only be used to set defaults",
+                    "description": "Base class for all Kafka connectors\\nShould only be used to set defaults",
                     "default": "kafka-connector",
                     "enum": [
                         "kafka-connector"
@@ -2378,7 +2378,7 @@ snapshots[
         },
         "KubernetesApp": {
             "title": "KubernetesApp",
-            "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+            "description": "Base class for all Kubernetes apps.\\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
             "type": "object",
             "properties": {
                 "type": {
@@ -2389,7 +2389,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Base class for all Kubernetes apps. All built-in components are Kubernetes apps, except for the Kafka connectors.",
+                    "description": "Base class for all Kubernetes apps.\\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
                     "default": "kubernetes-app",
                     "enum": [
                         "kubernetes-app"
@@ -2578,7 +2578,7 @@ snapshots[
         },
         "ProducerApp": {
             "title": "ProducerApp",
-            "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+            "description": "Producer component\\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
             "type": "object",
             "properties": {
                 "type": {
@@ -2589,7 +2589,7 @@ snapshots[
                 },
                 "type": {
                     "title": "Component type",
-                    "description": "Producer component This producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+                    "description": "Producer component\\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
                     "default": "producer",
                     "enum": [
                         "producer"
@@ -2822,7 +2822,7 @@ snapshots[
         },
         "StreamsAppConfig": {
             "title": "StreamsAppConfig",
-            "description": "StreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
+            "description": "\\nStreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
             "type": "object",
             "properties": {
                 "streams": {

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -1420,7 +1420,7 @@ snapshots[
         },
         "StreamsAppConfig": {
             "title": "StreamsAppConfig",
-            "description": "\\nStreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
+            "description": "StreamsBoostrap app configurations.\\nThe attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
             "type": "object",
             "properties": {
                 "streams": {
@@ -2822,7 +2822,7 @@ snapshots[
         },
         "StreamsAppConfig": {
             "title": "StreamsAppConfig",
-            "description": "\\nStreamsBoostrap app configurations. The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
+            "description": "StreamsBoostrap app configurations.\\nThe attributes correspond to keys and values that are used as values for the streams bootstrap helm chart. :params streams: Streams Bootstrap streams section",
             "type": "object",
             "properties": {
                 "streams": {


### PR DESCRIPTION
Also rename function describe_class more accurately as it can be used effectively on any string.