### PR TITLE
Add `kpops --version` command

### DIFF
--- a/docs/docs/user/references/cli-commands.md
+++ b/docs/docs/user/references/cli-commands.md
@@ -8,6 +8,7 @@ $ kpops [OPTIONS] COMMAND [ARGS]...
 
 **Options**:
 
+* `-V, --version`: Print KPOps version
 * `--install-completion`: Install completion for the current shell.
 * `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
 * `--help`: Show this message and exit.

--- a/kpops/__init__.py
+++ b/kpops/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("kpops")

--- a/kpops/__init__.py
+++ b/kpops/__init__.py
@@ -1,3 +1,1 @@
-import importlib.metadata
-
-__version__ = importlib.metadata.version("kpops")
+__version__ = "1.1.1"

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -355,7 +355,12 @@ def version_callback(show_version: bool) -> None:
 @app.callback()
 def main(
     version: bool = typer.Option(
-        False, "--version", "-V", callback=version_callback, is_eager=True
+        False,
+        "--version",
+        "-V",
+        help="Print KPOps version",
+        callback=version_callback,
+        is_eager=True,
     ),
 ):
     return

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Iterator, Optional
 
 import typer
 
+from kpops import __version__
 from kpops.cli.custom_formatter import CustomFormatter
 from kpops.cli.pipeline_config import ENV_PREFIX, PipelineConfig
 from kpops.cli.registry import Registry
@@ -343,6 +344,21 @@ def clean(
         log_action("Clean", component)
         component.destroy(dry_run)
         component.clean(dry_run)
+
+
+def version_callback(show_version: bool) -> None:
+    if show_version:
+        typer.echo(f"KPOps {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", "-V", callback=version_callback, is_eager=True
+    ),
+):
+    return
 
 
 if __name__ == "__main__":

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -363,7 +363,7 @@ def main(
         is_eager=True,
     ),
 ):
-    return
+    ...
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ mkdocs-glightbox = "^0.3.1"
 mike = "^1.1.2"
 typer-cli = "^0.0.13"
 
+[tool.poetry_bumpversion.file."kpops/__init__.py"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Closes #184

The ideas were taken from:

- _version.py file -> https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package
- Handling the version command -> https://github.com/tiangolo/typer/issues/52

Should be integrated in conjunction with the PR that changes bump action to bump the version in the new _version.py file (will paste it below in a moment)

[edit] the related ci-templates pull request can be found here https://github.com/bakdata/ci-templates/pull/95