### PR TITLE
Collapse pip install output for GitHub action

### DIFF
--- a/actions/kpops-runner/README.md
+++ b/actions/kpops-runner/README.md
@@ -5,16 +5,15 @@ This action runs KPOps with the given config.
 ## Input Parameters
 
 | Name              | Required | Default Value |  Type  | Description                                                                                                                                   |
-|-------------------|:--------:|:-------------:|:------:|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| command           |    ✅     |       -       | string | KPOps command to run. generate, deploy, destroy, reset, clean are possible values. Flags such as --dry-run and --execute need to be specified |
-| pipeline          |    ✅     |       -       | string | Pipeline to run by KPOps                                                                                                                      |
-| kpops-version     |    ✅     |       -       | string | KPOps version to use                                                                                                                          |
-| working-directory |    ❌     |       .       | string | root directory used by KPOps to run pipelines                                                                                                 |
-| pipeline-base-dir |    ❌     |       .       | string | directory where relative pipeline variables are initialized from                                                                              |
-| defaults          |    ❌     |   defaults    | string | defaults folder path                                                                                                                          |
-| config            |    ❌     |  config.yaml  | string | config.yaml file path                                                                                                                         |
-| components        |    ❌     |       -       | string | components package path                                                                                                                       |
-
+| ----------------- | :------: | :-----------: | :----: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| command           |    ✅    |       -       | string | KPOps command to run. generate, deploy, destroy, reset, clean are possible values. Flags such as --dry-run and --execute need to be specified |
+| pipeline          |    ✅    |       -       | string | Pipeline to run by KPOps                                                                                                                      |
+| kpops-version     |    ✅    |       -       | string | KPOps version to use                                                                                                                          |
+| working-directory |    ❌    |       .       | string | root directory used by KPOps to run pipelines                                                                                                 |
+| pipeline-base-dir |    ❌    |       .       | string | directory where relative pipeline variables are initialized from                                                                              |
+| defaults          |    ❌    |   defaults    | string | defaults folder path                                                                                                                          |
+| config            |    ❌    |  config.yaml  | string | config.yaml file path                                                                                                                         |
+| components        |    ❌    |       -       | string | components package path                                                                                                                       |
 
 ## Usage
 
@@ -26,5 +25,5 @@ steps:
       command: deploy --execute
       working-directory: home/my-kpops-root-dir
       pipeline: pipelines/my-pipeline-file.yaml
-      kpops-version: 0.3.0
+      kpops-version: 1.1.2
 ```

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -32,7 +32,10 @@ runs:
   steps:
     - name: Install KPOps
       shell: bash
-      run: pip install kpops==${{ inputs.kpops-version }}
+      run: |
+        echo "::group::pip install kpops package"
+        pip install kpops==${{ inputs.kpops-version }}
+        echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline
       shell: bash


### PR DESCRIPTION
usually we only want to see the output of `kpops <operation>` in the CI. This effectively hides the output of `pip install` by grouping the log https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-grouping-log-lines