### PR TITLE
Fix links to ATM-fraud defaults

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: poetry install --with docs
 
       - name: Test docs build (mkdocs)
-        run: poetry run mkdocs build
+        run: poetry run mkdocs build -f docs/mkdocs.yml
 
   publish:
     name: Publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,12 @@ jobs:
       - name: Test
         run: poetry run pytest tests
 
+      - name: Install docs dependencies
+        run: poetry install --with docs
+
+      - name: Test docs build (mkdocs)
+        run: poetry run mkdocs build
+
   publish:
     name: Publish
     needs: [test]

--- a/docs/docs/resources/examples/defaults.md
+++ b/docs/docs/resources/examples/defaults.md
@@ -5,7 +5,7 @@
 ??? example "defaults.yaml"
     ```yaml
         --8<--
-        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-deteection/defaults.yaml
+        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-detection/defaults.yaml
         --8<--
     ```
 

--- a/docs/docs/resources/examples/defaults.md
+++ b/docs/docs/resources/examples/defaults.md
@@ -1,11 +1,11 @@
 # Example `defaults.yaml` files
 
-## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-detection/defaults){target=_blank}
+## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-detection){target=_blank}
 
 ??? example "defaults.yaml"
     ```yaml
         --8<--
-        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-detection/defaults/defaults.yaml
+        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-detection/defaults.yaml
         --8<--
     ```
 

--- a/docs/docs/resources/examples/defaults.md
+++ b/docs/docs/resources/examples/defaults.md
@@ -1,6 +1,6 @@
 # Example `defaults.yaml` files
 
-## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-detection){target=_blank}
+## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-deteection){target=_blank}
 
 ??? example "defaults.yaml"
     ```yaml

--- a/docs/docs/resources/examples/defaults.md
+++ b/docs/docs/resources/examples/defaults.md
@@ -5,7 +5,7 @@
 ??? example "defaults.yaml"
     ```yaml
         --8<--
-        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-detection/defaults.yaml
+        https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-deteection/defaults.yaml
         --8<--
     ```
 

--- a/docs/docs/resources/examples/defaults.md
+++ b/docs/docs/resources/examples/defaults.md
@@ -1,6 +1,6 @@
 # Example `defaults.yaml` files
 
-## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-deteection){target=_blank}
+## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-detection){target=_blank}
 
 ??? example "defaults.yaml"
     ```yaml


### PR DESCRIPTION
Closes #220 
#216 updated the example pipeline file structure, but this was not reflected in the links to the docs.

See #218
