### PR TITLE
Disable broken Windows CI temporarily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2022, ubuntu-22.04 ]
+        os:
+          - ubuntu-22.04
+          # - windows-2022  # FIXME
         python-version: [ "3.10", "3.11" ]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ windows-2022, ubuntu-22.04 ]
         python-version: [ "3.10", "3.11" ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The windows ci tests are currently perma-broken