### PR TITLE
Set ANSI theme for output of `kpops generate`

### DIFF
--- a/kpops/pipeline_generator/pipeline.py
+++ b/kpops/pipeline_generator/pipeline.py
@@ -257,6 +257,7 @@ class Pipeline:
             substitute(str(self), substitution),
             "yaml",
             background_color="default",
+            theme="ansi_dark",
         )
         Console(
             width=1000  # HACK: overwrite console width to avoid truncating output


### PR DESCRIPTION
Closes #170 

### Before
| light | dark |
|--------|--------|
| <img width="510" alt="before_light" src="https://github.com/bakdata/kpops/assets/4771462/ec15207f-7ee8-4b6b-ba28-8c6a9075fbd2"> | <img width="510" alt="before_dark" src="https://github.com/bakdata/kpops/assets/4771462/784a18a1-4b46-444e-a79c-41eea3794b2d"> |

### After
| light | dark |
|--------|--------|
| <img width="510" alt="after_light" src="https://github.com/bakdata/kpops/assets/4771462/c49d56b6-aa89-452b-b87b-cf55bcbd2d49"> | <img width="510" alt="after_dark" src="https://github.com/bakdata/kpops/assets/4771462/e62f5216-493f-432a-b0b6-c1fa80118b69"> |