### PR TITLE
Refactor CLI using dtyper

### DIFF
--- a/docs/docs/user/references/cli-commands.md
+++ b/docs/docs/user/references/cli-commands.md
@@ -44,7 +44,7 @@ $ kpops clean [OPTIONS] PIPELINE_PATH [COMPONENTS_MODULE]
 * `--config FILE`: Path to the config.yaml file  [env var: KPOPS_CONFIG_PATH; default: config.yaml]
 * `--steps TEXT`: Comma separated list of steps to apply the command on  [env var: KPOPS_PIPELINE_STEPS]
 * `--dry-run / --execute`: Whether to dry run the command or execute it  [default: dry-run]
-* `--verbose / --no-verbose`: [default: no-verbose]
+* `--verbose / --no-verbose`: Enable verbose printing  [default: no-verbose]
 * `--help`: Show this message and exit.
 
 ## `kpops deploy`
@@ -67,8 +67,8 @@ $ kpops deploy [OPTIONS] PIPELINE_PATH [COMPONENTS_MODULE]
 * `--pipeline-base-dir DIRECTORY`: Base directory to the pipelines (default is current working directory)  [env var: KPOPS_PIPELINE_BASE_DIR; default: .]
 * `--defaults DIRECTORY`: Path to defaults folder  [env var: KPOPS_DEFAULT_PATH]
 * `--config FILE`: Path to the config.yaml file  [env var: KPOPS_CONFIG_PATH; default: config.yaml]
-* `--verbose / --no-verbose`: [default: no-verbose]
 * `--dry-run / --execute`: Whether to dry run the command or execute it  [default: dry-run]
+* `--verbose / --no-verbose`: Enable verbose printing  [default: no-verbose]
 * `--steps TEXT`: Comma separated list of steps to apply the command on  [env var: KPOPS_PIPELINE_STEPS]
 * `--help`: Show this message and exit.
 
@@ -93,8 +93,8 @@ $ kpops destroy [OPTIONS] PIPELINE_PATH [COMPONENTS_MODULE]
 * `--defaults DIRECTORY`: Path to defaults folder  [env var: KPOPS_DEFAULT_PATH]
 * `--config FILE`: Path to the config.yaml file  [env var: KPOPS_CONFIG_PATH; default: config.yaml]
 * `--steps TEXT`: Comma separated list of steps to apply the command on  [env var: KPOPS_PIPELINE_STEPS]
+* `--verbose / --no-verbose`: Enable verbose printing  [default: no-verbose]
 * `--dry-run / --execute`: Whether to dry run the command or execute it  [default: dry-run]
-* `--verbose / --no-verbose`: [default: no-verbose]
 * `--help`: Show this message and exit.
 
 ## `kpops generate`
@@ -147,7 +147,7 @@ $ kpops reset [OPTIONS] PIPELINE_PATH [COMPONENTS_MODULE]
 * `--config FILE`: Path to the config.yaml file  [env var: KPOPS_CONFIG_PATH; default: config.yaml]
 * `--steps TEXT`: Comma separated list of steps to apply the command on  [env var: KPOPS_PIPELINE_STEPS]
 * `--dry-run / --execute`: Whether to dry run the command or execute it  [default: dry-run]
-* `--verbose / --no-verbose`: [default: no-verbose]
+* `--verbose / --no-verbose`: Enable verbose printing  [default: no-verbose]
 * `--help`: Show this message and exit.
 
 ## `kpops schema`

--- a/kpops/__init__.py
+++ b/kpops/__init__.py
@@ -1,12 +1,12 @@
 __version__ = "1.3.2"
 
-# re-export public API functions
+# export public API functions
 from kpops.cli.main import clean, deploy, destroy, generate, reset
 
 __all__ = (
-    generate,
-    deploy,
-    destroy,
-    reset,
-    clean,
+    "generate",
+    "deploy",
+    "destroy",
+    "reset",
+    "clean",
 )

--- a/kpops/__init__.py
+++ b/kpops/__init__.py
@@ -1,1 +1,12 @@
 __version__ = "1.3.2"
+
+# re-export public API functions
+from kpops.cli.main import clean, deploy, destroy, generate, reset
+
+__all__ = (
+    generate,
+    deploy,
+    destroy,
+    reset,
+    clean,
+)

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -163,7 +163,9 @@ def get_steps_to_apply(
     return list(pipeline)
 
 
-def reverse_pipeline_steps(pipeline, steps) -> Iterator[PipelineComponent]:
+def reverse_pipeline_steps(
+    pipeline: Pipeline, steps: str | None
+) -> Iterator[PipelineComponent]:
     return reversed(get_steps_to_apply(pipeline, steps))
 
 

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional
 
+import dtyper
 import typer
 
 from kpops import __version__
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 LOG_DIVIDER = "#" * 100
 
-app = typer.Typer(pretty_exceptions_enable=False)
+app = dtyper.Typer(pretty_exceptions_enable=False)
 
 BASE_DIR_PATH_OPTION: Path = typer.Option(
     default=Path("."),
@@ -76,6 +77,8 @@ DRY_RUN: bool = typer.Option(
     "--dry-run/--execute",
     help="Whether to dry run the command or execute it",
 )
+
+VERBOSE_OPTION = typer.Option(False, help="Enable verbose printing")
 
 COMPONENTS_MODULES: str | None = typer.Argument(
     default=None,
@@ -219,12 +222,12 @@ def schema(
     help="Enriches pipelines steps with defaults. The output is used as input for the deploy/destroy/... commands."
 )
 def generate(
-    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
+    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     defaults: Optional[Path] = DEFAULT_PATH_OPTION,
     config: Path = CONFIG_PATH_OPTION,
-    verbose: bool = typer.Option(False, help="Enable verbose printing"),
+    verbose: bool = VERBOSE_OPTION,
     template: bool = typer.Option(False, help="Run Helm template"),
     steps: Optional[str] = PIPELINE_STEPS,
     api_version: Optional[str] = typer.Option(
@@ -261,13 +264,13 @@ def generate(
 
 @app.command(help="Deploy pipeline steps")
 def deploy(
-    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
+    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     defaults: Optional[Path] = DEFAULT_PATH_OPTION,
     config: Path = CONFIG_PATH_OPTION,
-    verbose: bool = False,
     dry_run: bool = DRY_RUN,
+    verbose: bool = VERBOSE_OPTION,
     steps: Optional[str] = PIPELINE_STEPS,
 ):
     pipeline_config = create_pipeline_config(config, defaults, verbose)
@@ -283,14 +286,14 @@ def deploy(
 
 @app.command(help="Destroy pipeline steps")
 def destroy(
-    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
+    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     defaults: Optional[Path] = DEFAULT_PATH_OPTION,
     config: Path = CONFIG_PATH_OPTION,
     steps: Optional[str] = PIPELINE_STEPS,
+    verbose: bool = VERBOSE_OPTION,
     dry_run: bool = DRY_RUN,
-    verbose: bool = False,
 ):
     pipeline_config = create_pipeline_config(config, defaults, verbose)
     pipeline = setup_pipeline(
@@ -304,14 +307,14 @@ def destroy(
 
 @app.command(help="Reset pipeline steps")
 def reset(
-    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
+    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     defaults: Optional[Path] = DEFAULT_PATH_OPTION,
     config: Path = CONFIG_PATH_OPTION,
     steps: Optional[str] = PIPELINE_STEPS,
     dry_run: bool = DRY_RUN,
-    verbose: bool = False,
+    verbose: bool = VERBOSE_OPTION,
 ):
     pipeline_config = create_pipeline_config(config, defaults, verbose)
     pipeline = setup_pipeline(
@@ -326,14 +329,14 @@ def reset(
 
 @app.command(help="Clean pipeline steps")
 def clean(
-    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
+    pipeline_base_dir: Path = BASE_DIR_PATH_OPTION,
     defaults: Optional[Path] = DEFAULT_PATH_OPTION,
     config: Path = CONFIG_PATH_OPTION,
     steps: Optional[str] = PIPELINE_STEPS,
     dry_run: bool = DRY_RUN,
-    verbose: bool = False,
+    verbose: bool = VERBOSE_OPTION,
 ):
     pipeline_config = create_pipeline_config(config, defaults, verbose)
     pipeline = setup_pipeline(

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -190,7 +190,7 @@ def create_pipeline_config(
     return pipeline_config
 
 
-@app.command(  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
     help="""
     Generate json schema.
 
@@ -220,7 +220,7 @@ def schema(
             gen_config_schema()
 
 
-@app.command(  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
     help="Enriches pipelines steps with defaults. The output is used as input for the deploy/destroy/... commands."
 )
 def generate(
@@ -264,7 +264,9 @@ def generate(
     return pipeline
 
 
-@app.command(help="Deploy pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(
+    help="Deploy pipeline steps"
+)  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
 def deploy(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -286,7 +288,9 @@ def deploy(
         component.deploy(dry_run)
 
 
-@app.command(help="Destroy pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(
+    help="Destroy pipeline steps"
+)  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
 def destroy(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -307,7 +311,9 @@ def destroy(
         component.destroy(dry_run)
 
 
-@app.command(help="Reset pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(
+    help="Reset pipeline steps"
+)  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
 def reset(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -329,7 +335,9 @@ def reset(
         component.reset(dry_run)
 
 
-@app.command(help="Clean pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
+@app.command(
+    help="Clean pipeline steps"
+)  # pyright: ignore[reportGeneralTypeIssues] https://github.com/rec/dtyper/issues/8
 def clean(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,

--- a/kpops/cli/main.py
+++ b/kpops/cli/main.py
@@ -188,7 +188,7 @@ def create_pipeline_config(
     return pipeline_config
 
 
-@app.command(
+@app.command(  # pyright: ignore[reportGeneralTypeIssues]
     help="""
     Generate json schema.
 
@@ -218,7 +218,7 @@ def schema(
             gen_config_schema()
 
 
-@app.command(
+@app.command(  # pyright: ignore[reportGeneralTypeIssues]
     help="Enriches pipelines steps with defaults. The output is used as input for the deploy/destroy/... commands."
 )
 def generate(
@@ -262,7 +262,7 @@ def generate(
     return pipeline
 
 
-@app.command(help="Deploy pipeline steps")
+@app.command(help="Deploy pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
 def deploy(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -284,7 +284,7 @@ def deploy(
         component.deploy(dry_run)
 
 
-@app.command(help="Destroy pipeline steps")
+@app.command(help="Destroy pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
 def destroy(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -305,7 +305,7 @@ def destroy(
         component.destroy(dry_run)
 
 
-@app.command(help="Reset pipeline steps")
+@app.command(help="Reset pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
 def reset(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,
@@ -327,7 +327,7 @@ def reset(
         component.reset(dry_run)
 
 
-@app.command(help="Clean pipeline steps")
+@app.command(help="Clean pipeline steps")  # pyright: ignore[reportGeneralTypeIssues]
 def clean(
     pipeline_path: Path = PIPELINE_PATH_ARG,
     components_module: Optional[str] = COMPONENTS_MODULES,

--- a/kpops/pipeline_generator/pipeline.py
+++ b/kpops/pipeline_generator/pipeline.py
@@ -51,6 +51,9 @@ class PipelineComponents(BaseModel):
     def __iter__(self) -> Iterator[PipelineComponent]:
         return iter(self.components)
 
+    def __len__(self) -> int:
+        return len(self.components)
+
     @staticmethod
     def _populate_component_name(component: PipelineComponent) -> None:
         component.name = component.prefix + component.name
@@ -272,6 +275,9 @@ class Pipeline:
                 self.components.json(exclude_none=True, by_alias=True)
             )
         )
+
+    def __len__(self) -> int:
+        return len(self.components)
 
     def substitute_in_component(self, component_as_dict: dict) -> dict:
         """Substitute all $-placeholders in a component in dict representation

--- a/poetry.lock
+++ b/poetry.lock
@@ -226,6 +226,20 @@ files = [
 ]
 
 [[package]]
+name = "dtyper"
+version = "2.1.0"
+description = "🗝 Make `typer` commands callable, or dataclasses 🗝"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "dtyper-2.1.0-py3-none-any.whl", hash = "sha256:331f513b33ccd43c1a803a2a06cdb879ed3925381aed9c04bd65470d58107ac6"},
+    {file = "dtyper-2.1.0.tar.gz", hash = "sha256:c18a7198c4d9f9194f862307dc326f2594acaffb8e2a6f81335ebc8bf6ed9e40"},
+]
+
+[package.dependencies]
+typer = "*"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.0.4"
 description = "Backport of PEP 654 (exception groups)"
@@ -1584,4 +1598,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2acbc93653bbe08133210f961c1bfe4087da573bb58ff824e8d53ecbe079bc01"
+content-hash = "6777adf06024f4e4627262cf73c157d15333b2954aba237b19e8e0651734c9bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pydantic = { extras = ["dotenv"], version = "^1.10.8" }
 rich = "^12.4.4"
 PyYAML = "^6.0"
 typer = { extras = ["all"], version = "^0.6.1" }
+dtyper = "^2.1.0"
 pyhumps = "^3.7.3"
 cachetools = "^5.2.0"
 dictdiffer = "^0.9.0"

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5,13 +5,14 @@ import yaml
 from snapshottest.module import SnapshotTest
 from typer.testing import CliRunner
 
+import kpops
 from kpops.cli.main import app
 from kpops.pipeline_generator.pipeline import ParsingException
 
 runner = CliRunner()
 
 RESOURCE_PATH = Path(__file__).parent / "resources"
-PIPELINE_BASE_DIR = str(RESOURCE_PATH.parent)
+PIPELINE_BASE_DIR_PATH = RESOURCE_PATH.parent
 
 
 class TestPipeline:
@@ -21,7 +22,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "first-pipeline/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -42,7 +43,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "name_prefix_concatenation/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -66,7 +67,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "pipeline-with-envs/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -86,7 +87,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "pipeline-with-inflate/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -106,7 +107,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "component-type-substitution/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -158,7 +159,7 @@ class TestPipeline:
                 [
                     "generate",
                     "--pipeline-base-dir",
-                    PIPELINE_BASE_DIR,
+                    str(PIPELINE_BASE_DIR_PATH),
                     str(
                         RESOURCE_PATH
                         / "component-type-substitution/infinite_pipeline.yaml"
@@ -176,7 +177,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "kafka-connect-sink-config/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH),
@@ -198,7 +199,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "no-input-topic-pipeline/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -218,7 +219,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "no-user-defined-components/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH),
@@ -238,7 +239,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "kafka-connect-sink/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH),
@@ -257,7 +258,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "read-from-component/pipeline.yaml"),
                 "tests.pipeline.test_components",
                 "--defaults",
@@ -277,7 +278,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "kafka-connect-sink/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH / "pipeline-with-env-defaults"),
@@ -296,7 +297,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(
                     RESOURCE_PATH
                     / "pipeline-component-should-have-prefix/pipeline.yaml"
@@ -320,7 +321,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "custom-config/pipeline.yaml"),
                 "--config",
                 str(RESOURCE_PATH / "custom-config/config.yaml"),
@@ -360,7 +361,7 @@ class TestPipeline:
                 [
                     "generate",
                     "--pipeline-base-dir",
-                    PIPELINE_BASE_DIR,
+                    str(PIPELINE_BASE_DIR_PATH),
                     str(RESOURCE_PATH / "custom-config/pipeline.yaml"),
                     "--config",
                     str(temp_config_path),
@@ -391,7 +392,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "custom-config/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH / "no-topics-defaults"),
@@ -421,7 +422,7 @@ class TestPipeline:
             [
                 "generate",
                 "--pipeline-base-dir",
-                PIPELINE_BASE_DIR,
+                str(PIPELINE_BASE_DIR_PATH),
                 str(RESOURCE_PATH / "pipeline-with-paths/pipeline.yaml"),
                 "--defaults",
                 str(RESOURCE_PATH),
@@ -441,7 +442,7 @@ class TestPipeline:
                 [
                     "generate",
                     "--pipeline-base-dir",
-                    PIPELINE_BASE_DIR,
+                    str(PIPELINE_BASE_DIR_PATH),
                     str(
                         RESOURCE_PATH
                         / "pipeline-with-illegal-kubernetes-name/pipeline.yaml"
@@ -452,3 +453,12 @@ class TestPipeline:
                 ],
                 catch_exceptions=False,
             )
+
+    def test_python_api(self):
+        pipeline = kpops.generate(
+            RESOURCE_PATH / "first-pipeline" / "pipeline.yaml",
+            "tests.pipeline.test_components",
+            pipeline_base_dir=PIPELINE_BASE_DIR_PATH,
+            defaults=RESOURCE_PATH,
+        )
+        assert len(pipeline) == 3

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -16,6 +16,15 @@ PIPELINE_BASE_DIR_PATH = RESOURCE_PATH.parent
 
 
 class TestPipeline:
+    def test_python_api(self):
+        pipeline = kpops.generate(
+            RESOURCE_PATH / "first-pipeline" / "pipeline.yaml",
+            "tests.pipeline.test_components",
+            pipeline_base_dir=PIPELINE_BASE_DIR_PATH,
+            defaults=RESOURCE_PATH,
+        )
+        assert len(pipeline) == 3
+
     def test_load_pipeline(self, snapshot: SnapshotTest):
         result = runner.invoke(
             app,
@@ -453,12 +462,3 @@ class TestPipeline:
                 ],
                 catch_exceptions=False,
             )
-
-    def test_python_api(self):
-        pipeline = kpops.generate(
-            RESOURCE_PATH / "first-pipeline" / "pipeline.yaml",
-            "tests.pipeline.test_components",
-            pipeline_base_dir=PIPELINE_BASE_DIR_PATH,
-            defaults=RESOURCE_PATH,
-        )
-        assert len(pipeline) == 3


### PR DESCRIPTION
Typer doesn't allow calling commands from outside its context. `dtyper` acts as a slim wrapper to patch this drawback, making it possible to import the commands from an external Python module. This is the first step towards providing a developer API that allows to hook into the kpops operations.
