### PR TITLE
Automatically support schema generation for custom components

### DIFF
--- a/docs/docs/schema/config.json
+++ b/docs/docs/schema/config.json
@@ -220,5 +220,5 @@
             "type": "object"
         }
     },
-    "title": "kpops config schema"
+    "title": "KPOps config schema"
 }

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -171,11 +171,6 @@
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
                 },
-                "type": {
-                    "default": "kafka-app",
-                    "title": "Type",
-                    "type": "string"
-                },
                 "version": {
                     "default": "2.9.0",
                     "description": "Helm chart version",
@@ -303,11 +298,6 @@
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
                 },
-                "type": {
-                    "default": "kafka-connector",
-                    "title": "Type",
-                    "type": "string"
-                },
                 "version": {
                     "default": "1.0.4",
                     "description": "Helm chart version",
@@ -401,11 +391,6 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
-                },
-                "type": {
-                    "default": "kafka-sink-connector",
-                    "title": "Type",
-                    "type": "string"
                 },
                 "version": {
                     "default": "1.0.4",
@@ -506,11 +491,6 @@
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
                 },
-                "type": {
-                    "default": "kafka-source-connector",
-                    "title": "Type",
-                    "type": "string"
-                },
                 "version": {
                     "default": "1.0.4",
                     "description": "Helm chart version",
@@ -610,11 +590,6 @@
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
                 },
-                "type": {
-                    "default": "kubernetes-app",
-                    "title": "Type",
-                    "type": "string"
-                },
                 "version": {
                     "description": "Helm chart version",
                     "title": "Version",
@@ -685,11 +660,6 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
-                },
-                "type": {
-                    "default": "pipeline-component",
-                    "title": "Type",
-                    "type": "string"
                 }
             },
             "required": [
@@ -767,11 +737,6 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
-                },
-                "type": {
-                    "default": "producer",
-                    "title": "Type",
-                    "type": "string"
                 },
                 "version": {
                     "default": "2.9.0",
@@ -948,11 +913,6 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
-                },
-                "type": {
-                    "default": "streams-app",
-                    "title": "Type",
-                    "type": "string"
                 },
                 "version": {
                     "default": "2.9.0",

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -173,7 +173,6 @@
                 },
                 "type": {
                     "default": "kafka-app",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -306,7 +305,6 @@
                 },
                 "type": {
                     "default": "kafka-connector",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -406,7 +404,6 @@
                 },
                 "type": {
                     "default": "kafka-sink-connector",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -511,7 +508,6 @@
                 },
                 "type": {
                     "default": "kafka-source-connector",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -616,7 +612,6 @@
                 },
                 "type": {
                     "default": "kubernetes-app",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -692,7 +687,6 @@
                     "title": "To"
                 },
                 "type": {
-                    "const": "pipeline-component",
                     "default": "pipeline-component",
                     "title": "Type",
                     "type": "string"
@@ -776,7 +770,6 @@
                 },
                 "type": {
                     "default": "producer",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },
@@ -958,7 +951,6 @@
                 },
                 "type": {
                     "default": "streams-app",
-                    "description": "Component type",
                     "title": "Type",
                     "type": "string"
                 },

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -1229,6 +1229,6 @@
             }
         ]
     },
-    "title": "kpops pipeline schema",
+    "title": "KPOps pipeline schema",
     "type": "array"
 }

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -168,7 +168,7 @@
                     "enum": [
                         "kafka-app"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -295,7 +295,7 @@
                     "enum": [
                         "kafka-connector"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -389,7 +389,7 @@
                     "enum": [
                         "kafka-sink-connector"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -488,7 +488,7 @@
                     "enum": [
                         "kafka-source-connector"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -587,7 +587,7 @@
                     "enum": [
                         "kubernetes-app"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -735,7 +735,7 @@
                     "enum": [
                         "producer"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {
@@ -911,7 +911,7 @@
                     "enum": [
                         "streams-app"
                     ],
-                    "title": "Type",
+                    "title": "Component type",
                     "type": "string"
                 },
                 "version": {

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -153,15 +153,6 @@
                     "description": "Configuration of the Helm chart repo to be used for deploying the component",
                     "title": "Repoconfig"
                 },
-                "type": {
-                    "default": "kafka-app",
-                    "description": "Base component for Kafka-based components.\nProducer or streaming apps should inherit from this class.",
-                    "enum": [
-                        "kafka-app"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -170,6 +161,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "kafka-app",
+                    "description": "Base component for Kafka-based components.\nProducer or streaming apps should inherit from this class.",
+                    "enum": [
+                        "kafka-app"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "2.9.0",
@@ -280,15 +280,6 @@
                     "title": "Resettervalues",
                     "type": "object"
                 },
-                "type": {
-                    "default": "kafka-connector",
-                    "description": "Base class for all Kafka connectors\nShould only be used to set defaults",
-                    "enum": [
-                        "kafka-connector"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -297,6 +288,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "kafka-connector",
+                    "description": "Base class for all Kafka connectors\nShould only be used to set defaults",
+                    "enum": [
+                        "kafka-connector"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "1.0.4",
@@ -374,15 +374,6 @@
                     "title": "Resettervalues",
                     "type": "object"
                 },
-                "type": {
-                    "default": "kafka-sink-connector",
-                    "description": "Kafka sink connector model",
-                    "enum": [
-                        "kafka-sink-connector"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -391,6 +382,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "kafka-sink-connector",
+                    "description": "Kafka sink connector model",
+                    "enum": [
+                        "kafka-sink-connector"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "1.0.4",
@@ -473,15 +473,6 @@
                     "title": "Resettervalues",
                     "type": "object"
                 },
-                "type": {
-                    "default": "kafka-source-connector",
-                    "description": "Kafka source connector model",
-                    "enum": [
-                        "kafka-source-connector"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -490,6 +481,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "kafka-source-connector",
+                    "description": "Kafka source connector model",
+                    "enum": [
+                        "kafka-source-connector"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "1.0.4",
@@ -572,15 +572,6 @@
                     "description": "Configuration of the Helm chart repo to be used for deploying the component",
                     "title": "Repoconfig"
                 },
-                "type": {
-                    "default": "kubernetes-app",
-                    "description": "Base class for all Kubernetes apps.\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
-                    "enum": [
-                        "kubernetes-app"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -589,6 +580,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "kubernetes-app",
+                    "description": "Base class for all Kubernetes apps.\nAll built-in components are Kubernetes apps, except for the Kafka connectors.",
+                    "enum": [
+                        "kubernetes-app"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "description": "Helm chart version",
@@ -643,15 +643,6 @@
                     "title": "Prefix",
                     "type": "string"
                 },
-                "type": {
-                    "default": "pipeline-component",
-                    "description": "Base class for all components",
-                    "enum": [
-                        "pipeline-component"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -660,6 +651,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "pipeline-component",
+                    "description": "Base class for all components",
+                    "enum": [
+                        "pipeline-component"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 }
             },
             "required": [
@@ -720,15 +720,6 @@
                     "description": "Configuration of the Helm chart repo to be used for deploying the component",
                     "title": "Repoconfig"
                 },
-                "type": {
-                    "default": "producer",
-                    "description": "Producer component\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
-                    "enum": [
-                        "producer"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -737,6 +728,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "producer",
+                    "description": "Producer component\nThis producer holds configuration to use as values for the streams bootstrap producer helm chart.",
+                    "enum": [
+                        "producer"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "2.9.0",
@@ -896,15 +896,6 @@
                     "description": "Configuration of the Helm chart repo to be used for deploying the component",
                     "title": "Repoconfig"
                 },
-                "type": {
-                    "default": "streams-app",
-                    "description": "StreamsApp component that configures a streams bootstrap app",
-                    "enum": [
-                        "streams-app"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -913,6 +904,15 @@
                     ],
                     "description": "Topic(s) into which the component will write output",
                     "title": "To"
+                },
+                "type": {
+                    "default": "streams-app",
+                    "description": "StreamsApp component that configures a streams bootstrap app",
+                    "enum": [
+                        "streams-app"
+                    ],
+                    "title": "Type",
+                    "type": "string"
                 },
                 "version": {
                     "default": "2.9.0",

--- a/hooks/gen_schema.py
+++ b/hooks/gen_schema.py
@@ -26,5 +26,6 @@ def gen_schema(scope: SchemaScope):
         Path(PATH_TO_SCHEMA / f"{scope.value}.json").write_text(f.getvalue())
 
 
-gen_schema(SchemaScope.PIPELINE)
-gen_schema(SchemaScope.CONFIG)
+if __name__ == "__main__":
+    gen_schema(SchemaScope.PIPELINE)
+    gen_schema(SchemaScope.CONFIG)

--- a/kpops/components/base_components/base_defaults_component.py
+++ b/kpops/components/base_components/base_defaults_component.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from kpops.cli.pipeline_config import PipelineConfig
 from kpops.component_handlers import ComponentHandlers
 from kpops.utils.dict_ops import update_nested
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.environment import ENV
 from kpops.utils.pydantic import DescConfig
 from kpops.utils.yaml_loading import load_yaml_file
@@ -40,7 +40,7 @@ class BaseDefaultsComponent(BaseModel):
 
     type: str = Field(
         default=...,
-        description=describe_object(__doc__),
+        description=describe_attr("type", __doc__),
         const=True,
     )
     enrich: bool = Field(

--- a/kpops/components/base_components/base_defaults_component.py
+++ b/kpops/components/base_components/base_defaults_component.py
@@ -38,7 +38,11 @@ class BaseDefaultsComponent(BaseModel):
     :type validate: bool, optional
     """
 
-    type: str = Field(default=...)
+    type: str = Field(
+        default=...,
+        title=describe_attr("type", __doc__),
+        const=True,
+    )
     enrich: bool = Field(
         default=False,
         description=describe_attr("enrich", __doc__),

--- a/kpops/components/base_components/base_defaults_component.py
+++ b/kpops/components/base_components/base_defaults_component.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from kpops.cli.pipeline_config import PipelineConfig
 from kpops.component_handlers import ComponentHandlers
 from kpops.utils.dict_ops import update_nested
-from kpops.utils.docstring import describe_attr
+from kpops.utils.docstring import describe_attr, describe_object
 from kpops.utils.environment import ENV
 from kpops.utils.pydantic import DescConfig
 from kpops.utils.yaml_loading import load_yaml_file
@@ -39,7 +39,9 @@ class BaseDefaultsComponent(BaseModel):
     """
 
     type: str = Field(
-        default=..., description=describe_attr("type", __doc__), const=True
+        default=...,
+        description=describe_object(__doc__),
+        const=True,
     )
     enrich: bool = Field(
         default=False,

--- a/kpops/components/base_components/base_defaults_component.py
+++ b/kpops/components/base_components/base_defaults_component.py
@@ -38,11 +38,7 @@ class BaseDefaultsComponent(BaseModel):
     :type validate: bool, optional
     """
 
-    type: str = Field(
-        default=...,
-        description=describe_attr("type", __doc__),
-        const=True,
-    )
+    type: str = Field(...)
     enrich: bool = Field(
         default=False,
         description=describe_attr("enrich", __doc__),

--- a/kpops/components/base_components/base_defaults_component.py
+++ b/kpops/components/base_components/base_defaults_component.py
@@ -38,7 +38,7 @@ class BaseDefaultsComponent(BaseModel):
     :type validate: bool, optional
     """
 
-    type: str = Field(...)
+    type: str = Field(default=...)
     enrich: bool = Field(
         default=False,
         description=describe_attr("enrich", __doc__),

--- a/kpops/components/base_components/kafka_app.py
+++ b/kpops/components/base_components/kafka_app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from pydantic import BaseModel, Extra, Field
 from typing_extensions import override
@@ -15,7 +14,7 @@ from kpops.components.base_components.kubernetes_app import (
     KubernetesApp,
     KubernetesAppConfig,
 )
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 
 log = logging.getLogger("KafkaApp")
@@ -76,13 +75,7 @@ class KafkaApp(KubernetesApp):
     :type version: str, optional
     """
 
-    type: str = Field(default="kafka-app", description="Component type")
-    schema_type: Literal["kafka-app"] = Field(
-        default="kafka-app",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "kafka-app"
     app: KafkaAppConfig = Field(
         default=...,
         description=describe_attr("app", __doc__),

--- a/kpops/components/base_components/kafka_app.py
+++ b/kpops/components/base_components/kafka_app.py
@@ -62,9 +62,6 @@ class KafkaApp(KubernetesApp):
 
     :param type: Component type, defaults to "kafka-app"
     :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "kafka-app"
-    :type schema_type: Literal["kafka-app"], optional
     :param app: Application-specific settings
     :type app: KafkaAppConfig
     :param repo_config: Configuration of the Helm chart repo to be used for

--- a/kpops/components/base_components/kafka_connector.py
+++ b/kpops/components/base_components/kafka_connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from functools import cached_property
-from typing import Literal, NoReturn
+from typing import NoReturn
 
 from pydantic import Field
 from typing_extensions import override
@@ -27,7 +27,7 @@ from kpops.components.base_components.base_defaults_component import deduplicate
 from kpops.components.base_components.models.from_section import FromTopic
 from kpops.components.base_components.pipeline_component import PipelineComponent
 from kpops.utils.colorify import magentaify
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfig
 
 log = logging.getLogger("KafkaConnector")
@@ -58,13 +58,7 @@ class KafkaConnector(PipelineComponent, ABC):
     :type resetter_values: dict, optional
     """
 
-    type: str = Field(default="kafka-connector", description="Component type")
-    schema_type: Literal["kafka-connector"] = Field(
-        default="kafka-connector",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "kafka-connector"
     app: KafkaConnectConfig = Field(
         default=...,
         description=describe_attr("app", __doc__),
@@ -309,16 +303,7 @@ class KafkaSourceConnector(KafkaConnector):
     :type schema_type: str, optional
     """
 
-    type: str = Field(
-        default="kafka-source-connector",
-        description=describe_attr("type", __doc__),
-    )
-    schema_type: Literal["kafka-source-connector"] = Field(
-        default="kafka-source-connector",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "kafka-source-connector"
     offset_topic: str | None = Field(
         default=None,
         description=describe_attr("offset_topic", __doc__),
@@ -381,16 +366,7 @@ class KafkaSinkConnector(KafkaConnector):
     :type schema_type: Literal["kafka-sink-connector"], optional
     """
 
-    type: str = Field(
-        default="kafka-sink-connector",
-        description=describe_attr("type", __doc__),
-    )
-    schema_type: Literal["kafka-sink-connector"] = Field(
-        default="kafka-sink-connector",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "kafka-sink-connector"
 
     @override
     def add_input_topics(self, topics: list[str]) -> None:

--- a/kpops/components/base_components/kafka_connector.py
+++ b/kpops/components/base_components/kafka_connector.py
@@ -40,9 +40,6 @@ class KafkaConnector(PipelineComponent, ABC):
 
     :param type: Component type, defaults to "kafka-connector"
     :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "kafka-connector"
-    :type schema_type: Literal["kafka-connector"], optional
     :param app: Application-specific settings
     :type app: KafkaAppConfig
     :param repo_config: Configuration of the Helm chart repo to be used for
@@ -293,14 +290,9 @@ class KafkaSourceConnector(KafkaConnector):
     """Kafka source connector model
 
     :param type: Component type, defaults to "kafka-source-connector"
-    :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "kafka-source-connector"
-    :type schema_type: Literal["kafka-source-connector"], optional
     :param offset_topic: offset.storage.topic,
         more info: https://kafka.apache.org/documentation/#connect_running,
         defaults to None
-    :type schema_type: str, optional
     """
 
     type = "kafka-source-connector"
@@ -360,10 +352,6 @@ class KafkaSinkConnector(KafkaConnector):
     """Kafka sink connector model
 
     :param type: Component type, defaults to "kafka-sink-connector"
-    :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "kafka-sink-connector"
-    :type schema_type: Literal["kafka-sink-connector"], optional
     """
 
     type = "kafka-sink-connector"

--- a/kpops/components/base_components/kubernetes_app.py
+++ b/kpops/components/base_components/kubernetes_app.py
@@ -50,10 +50,7 @@ class KubernetesApp(PipelineComponent):
     :param version: Helm chart version, defaults to None
     """
 
-    type: str = Field(
-        default="kubernetes-app",
-        description=describe_attr("type", __doc__),
-    )
+    type = "kubernetes-app"
     schema_type: Literal["kubernetes-app"] = Field(
         default="kubernetes-app",
         title="Component type",

--- a/kpops/components/base_components/kubernetes_app.py
+++ b/kpops/components/base_components/kubernetes_app.py
@@ -41,8 +41,6 @@ class KubernetesApp(PipelineComponent):
     All built-in components are Kubernetes apps, except for the Kafka connectors.
 
     :param type: Component type, defaults to "kubernetes-app"
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "kubernetes-app"
     :param app: Application-specific settings
     :param repo_config: Configuration of the Helm chart repo to be used for
         deploying the component, defaults to None

--- a/kpops/components/base_components/kubernetes_app.py
+++ b/kpops/components/base_components/kubernetes_app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from functools import cached_property
-from typing import Any, Literal
+from typing import Any
 
 from pydantic import BaseModel, Extra, Field
 from typing_extensions import override
@@ -18,7 +18,7 @@ from kpops.component_handlers.helm_wrapper.model import (
 )
 from kpops.components.base_components.pipeline_component import PipelineComponent
 from kpops.utils.colorify import magentaify
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 
 log = logging.getLogger("KubernetesAppComponent")
@@ -51,12 +51,6 @@ class KubernetesApp(PipelineComponent):
     """
 
     type = "kubernetes-app"
-    schema_type: Literal["kubernetes-app"] = Field(
-        default="kubernetes-app",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
     app: KubernetesAppConfig = Field(
         default=...,
         description=describe_attr("app", __doc__),

--- a/kpops/components/base_components/pipeline_component.py
+++ b/kpops/components/base_components/pipeline_component.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Literal
 
 from pydantic import Extra, Field
 
@@ -18,7 +17,7 @@ from kpops.components.base_components.models.to_section import (
     TopicConfig,
     ToSection,
 )
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfig, DescConfig
 
 
@@ -40,12 +39,6 @@ class PipelineComponent(BaseDefaultsComponent):
     """
 
     type = "pipeline-component"
-    schema_type: Literal["pipeline-component"] = Field(
-        default="pipeline-component",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
     name: str = Field(default=..., description=describe_attr("name", __doc__))
     prefix: str = Field(
         default="${pipeline_name}-",

--- a/kpops/components/base_components/pipeline_component.py
+++ b/kpops/components/base_components/pipeline_component.py
@@ -39,11 +39,7 @@ class PipelineComponent(BaseDefaultsComponent):
     :type to: ToSection, optional
     """
 
-    type: str = Field(
-        default="pipeline-component",
-        description=describe_attr("type", __doc__),
-        const=True,
-    )
+    type = "pipeline-component"
     schema_type: Literal["pipeline-component"] = Field(
         default="pipeline-component",
         title="Component type",

--- a/kpops/components/streams_bootstrap/producer/producer_app.py
+++ b/kpops/components/streams_bootstrap/producer/producer_app.py
@@ -21,9 +21,6 @@ class ProducerApp(KafkaApp):
 
     :param type: Component type, defaults to "producer"
     :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "producer"
-    :type schema_type: Literal["producer"], optional
     :param app: Application-specific settings
     :type app: ProducerValues
     :param from_: Producer doesn't support FromSection, defaults to None

--- a/kpops/components/streams_bootstrap/producer/producer_app.py
+++ b/kpops/components/streams_bootstrap/producer/producer_app.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseConfig, Extra, Field
 from typing_extensions import override
 
@@ -12,7 +10,7 @@ from kpops.components.base_components.models.to_section import (
 )
 from kpops.components.streams_bootstrap.app_type import AppType
 from kpops.components.streams_bootstrap.producer.model import ProducerValues
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 
 
 class ProducerApp(KafkaApp):
@@ -32,13 +30,7 @@ class ProducerApp(KafkaApp):
     :type from_: None, optional
     """
 
-    type: str = Field(default="producer", description="Component type")
-    schema_type: Literal["producer"] = Field(
-        default="producer",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "producer"
     app: ProducerValues = Field(
         default=...,
         description=describe_attr("app", __doc__),

--- a/kpops/components/streams_bootstrap/streams/streams_app.py
+++ b/kpops/components/streams_bootstrap/streams/streams_app.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import Extra, Field
 from typing_extensions import override
 
 from kpops.components.base_components.kafka_app import KafkaApp
 from kpops.components.streams_bootstrap.app_type import AppType
 from kpops.components.streams_bootstrap.streams.model import StreamsAppConfig
-from kpops.utils.docstring import describe_attr, describe_object
+from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import DescConfig
 
 
@@ -24,16 +22,7 @@ class StreamsApp(KafkaApp):
     :type app: StreamsAppConfig
     """
 
-    type: str = Field(
-        default="streams-app",
-        description=describe_attr("type", __doc__),
-    )
-    schema_type: Literal["streams-app"] = Field(
-        default="streams-app",
-        title="Component type",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "streams-app"
     app: StreamsAppConfig = Field(
         default=...,
         description=describe_attr("app", __doc__),

--- a/kpops/components/streams_bootstrap/streams/streams_app.py
+++ b/kpops/components/streams_bootstrap/streams/streams_app.py
@@ -15,9 +15,6 @@ class StreamsApp(KafkaApp):
 
     :param type: Component type, defaults to "streams-app"
     :type type: str, optional
-    :param schema_type: Used for schema generation, same as :param:`type`,
-        defaults to "streams-app"
-    :type schema_type: Literal["streams-app"], optional
     :param app: Application-specific settings
     :type app: StreamsAppConfig
     """

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -77,11 +77,11 @@ def _add_components(
     defined_component_types: set[str] = {
         component.get_component_type() for component in components
     }
-    custom_components = [
+    custom_components = (
         component
         for component in _find_classes(components_module, PipelineComponent)
         if _is_valid_component(defined_component_types, component)
-    ]
+    )
     components += tuple(custom_components)
     return components
 

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -150,6 +150,8 @@ def gen_pipeline_schema(
             class_validators=None,
             model_config=BaseConfig,
         )
+        # drop duplicate component type
+        component.__fields__.pop("type")
 
     AnnotatedPipelineComponents = Annotated[
         PipelineComponents, Field(discriminator="schema_type")

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -75,9 +75,7 @@ def _add_components(
         components = tuple()
     # Set of existing types, against which to check the new ones
     defined_component_types: set[str] = {
-        component.__fields__["type"].default
-        for component in components
-        if component.__fields__.get("type")
+        component.__fields__["type"].default for component in components
     }
     custom_components = [
         component
@@ -116,14 +114,10 @@ def gen_pipeline_schema(
 
     # re-assign component type as Literal to work as discriminator
     for component in components:
-        component_type = component.get_component_type()
-        component.__fields__["type"].type_ = Literal[component_type]  # type: ignore
-        component.__fields__["type"].field_info.title = describe_attr(
-            "type", component.__doc__
-        )
-        component.__fields__["type"].field_info.description = describe_object(
-            component.__doc__
-        )
+        component_type_field = component.__fields__["type"]
+        component_type_field.type_ = Literal[component.get_component_type()]  # type: ignore
+        component_type_field.field_info.title = describe_attr("type", component.__doc__)
+        component_type_field.field_info.description = describe_object(component.__doc__)
 
     AnnotatedPipelineComponents = Annotated[
         PipelineComponents, Field(discriminator="type")

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -75,7 +75,7 @@ def _add_components(
         components = tuple()
     # Set of existing types, against which to check the new ones
     defined_component_types: set[str] = {
-        component.__fields__["type"].default for component in components
+        component.get_component_type() for component in components
     }
     custom_components = [
         component

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -125,7 +125,7 @@ def gen_pipeline_schema(
 
     schema = schema_json_of(
         Sequence[AnnotatedPipelineComponents],
-        title="kpops pipeline schema",
+        title="KPOps pipeline schema",
         by_alias=True,
         indent=4,
         sort_keys=True,
@@ -136,6 +136,6 @@ def gen_pipeline_schema(
 def gen_config_schema() -> None:
     """Generate a json schema from the model of pipeline config"""
     schema = schema_json_of(
-        PipelineConfig, title="kpops config schema", indent=4, sort_keys=True
+        PipelineConfig, title="KPOps config schema", indent=4, sort_keys=True
     )
     print(schema)

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -2,7 +2,7 @@ import logging
 from enum import Enum
 from typing import Annotated, Any, Literal, Sequence, Union, get_args, get_origin
 
-from pydantic import BaseConfig, Field, schema, schema_json_of
+from pydantic import Field, schema, schema_json_of
 from pydantic.fields import ModelField
 from pydantic.schema import SkipField
 
@@ -139,16 +139,9 @@ def gen_pipeline_schema(
     # dynamically assign schema type discriminator
     for component in components:
         component_type = component.get_component_type()
-        field_info = component.__fields__["type"].field_info
-        field_info.description = describe_object(component.__doc__)
-        component.__fields__["type"] = ModelField(
-            name="type",
-            type_=Literal[component_type],  # type: ignore
-            required=False,
-            default=component_type,
-            field_info=field_info,
-            class_validators=None,
-            model_config=BaseConfig,
+        component.__fields__["type"].type_ = Literal[component_type]  # type: ignore
+        component.__fields__["type"].field_info.description = describe_object(
+            component.__doc__
         )
 
     AnnotatedPipelineComponents = Annotated[

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -74,7 +74,7 @@ def _add_components(
     if components is None:
         components = tuple()
     # Set of existing types, against which to check the new ones
-    defined_component_types: set[str] = {
+    defined_component_types = {
         component.get_component_type() for component in components
     }
     custom_components = (

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -9,7 +9,7 @@ from pydantic.schema import SkipField
 from kpops.cli.pipeline_config import PipelineConfig
 from kpops.cli.registry import _find_classes
 from kpops.components.base_components.pipeline_component import PipelineComponent
-from kpops.utils.docstring import describe_object
+from kpops.utils.docstring import describe_attr, describe_object
 
 
 class SchemaScope(str, Enum):
@@ -118,6 +118,9 @@ def gen_pipeline_schema(
     for component in components:
         component_type = component.get_component_type()
         component.__fields__["type"].type_ = Literal[component_type]  # type: ignore
+        component.__fields__["type"].field_info.title = describe_attr(
+            "type", component.__doc__
+        )
         component.__fields__["type"].field_info.description = describe_object(
             component.__doc__
         )

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -139,10 +139,10 @@ def gen_pipeline_schema(
     # dynamically assign schema type discriminator
     for component in components:
         component_type = component.get_component_type()
-        field_info = component.__fields__["schema_type"].field_info
+        field_info = component.__fields__["type"].field_info
         field_info.description = describe_object(component.__doc__)
-        component.__fields__["schema_type"] = ModelField(
-            name="schema_type",
+        component.__fields__["type"] = ModelField(
+            name="type",
             type_=Literal[component_type],  # type: ignore
             required=False,
             default=component_type,
@@ -150,11 +150,9 @@ def gen_pipeline_schema(
             class_validators=None,
             model_config=BaseConfig,
         )
-        # drop duplicate component type
-        component.__fields__.pop("type")
 
     AnnotatedPipelineComponents = Annotated[
-        PipelineComponents, Field(discriminator="schema_type")
+        PipelineComponents, Field(discriminator="type")
     ]
 
     schema = schema_json_of(
@@ -163,7 +161,7 @@ def gen_pipeline_schema(
         by_alias=True,
         indent=4,
         sort_keys=True,
-    ).replace("schema_type", "type")
+    )
     print(schema)
 
 

--- a/kpops/utils/gen_schema.py
+++ b/kpops/utils/gen_schema.py
@@ -114,7 +114,7 @@ def gen_pipeline_schema(
     # Create a type union that will hold the union of all component types
     PipelineComponents = Union[components]  # type: ignore[valid-type]
 
-    # dynamically assign schema type discriminator
+    # re-assign component type as Literal to work as discriminator
     for component in components:
         component_type = component.get_component_type()
         component.__fields__["type"].type_ = Literal[component_type]  # type: ignore

--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -7,8 +7,6 @@ from kpops.utils.docstring import describe_object
 
 
 def to_camel(field: str) -> str:
-    if field == "schema_type":
-        return field
     return humps.camelize(field)
 
 

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -379,7 +379,7 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
             }
         ]
     },
-    "title": "kpops pipeline schema",
+    "title": "KPOps pipeline schema",
     "type": "array"
 }
 '''

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -32,15 +32,6 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "Prefix",
                     "type": "string"
                 },
-                "type": {
-                    "default": "pipeline-component",
-                    "description": "Base class for all components",
-                    "enum": [
-                        "pipeline-component"
-                    ],
-                    "title": "Component type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -51,8 +42,10 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "To"
                 },
                 "type": {
-                    "const": "pipeline-component",
                     "default": "pipeline-component",
+                    "enum": [
+                        "pipeline-component"
+                    ],
                     "title": "Type",
                     "type": "string"
                 }
@@ -157,14 +150,6 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "Prefix",
                     "type": "string"
                 },
-                "type": {
-                    "default": "sub-pipeline-component",
-                    "enum": [
-                        "sub-pipeline-component"
-                    ],
-                    "title": "Schema Type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -176,6 +161,9 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                 },
                 "type": {
                     "default": "sub-pipeline-component",
+                    "enum": [
+                        "sub-pipeline-component"
+                    ],
                     "title": "Type",
                     "type": "string"
                 }
@@ -209,14 +197,6 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "Prefix",
                     "type": "string"
                 },
-                "type": {
-                    "default": "sub-pipeline-component-correct",
-                    "enum": [
-                        "sub-pipeline-component-correct"
-                    ],
-                    "title": "Schema Type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -228,6 +208,9 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                 },
                 "type": {
                     "default": "sub-pipeline-component-correct",
+                    "enum": [
+                        "sub-pipeline-component-correct"
+                    ],
                     "title": "Type",
                     "type": "string"
                 }
@@ -261,15 +244,6 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "Prefix",
                     "type": "string"
                 },
-                "type": {
-                    "default": "sub-pipeline-component-correct-docstr",
-                    "description": "Newline before title is removed\\nSummarry is correctly imported. All whitespaces are removed and replaced with a single space. The description extraction terminates at the correct place, deletes 1 trailing coma",
-                    "enum": [
-                        "sub-pipeline-component-correct-docstr"
-                    ],
-                    "title": "Schema Type",
-                    "type": "string"
-                },
                 "to": {
                     "allOf": [
                         {
@@ -280,9 +254,11 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "title": "To"
                 },
                 "type": {
-                    "const": "sub-pipeline-component-correct-docstr",
                     "default": "sub-pipeline-component-correct-docstr",
-                    "description": "Parameter description looks correct and it is not included in the class description, terminates here",
+                    "description": "Newline before title is removed\\nSummarry is correctly imported. All whitespaces are removed and replaced with a single space. The description extraction terminates at the correct place, deletes 1 trailing coma",
+                    "enum": [
+                        "sub-pipeline-component-correct-docstr"
+                    ],
                     "title": "Type",
                     "type": "string"
                 }

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -259,7 +259,7 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "enum": [
                         "sub-pipeline-component-correct-docstr"
                     ],
-                    "title": "Type",
+                    "title": "Parameter description looks correct and it is not included in the class description, terminates here",
                     "type": "string"
                 }
             },

--- a/tests/cli/test_schema_generation.py
+++ b/tests/cli/test_schema_generation.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Literal
 
 import pytest
-from pydantic import Field
 from snapshottest.module import SnapshotTest
 from typer.testing import CliRunner
 
 from kpops.cli.main import app
 from kpops.components.base_components import PipelineComponent
-from kpops.utils.docstring import describe_attr, describe_object
 
 RESOURCE_PATH = Path(__file__).parent / "resources"
 
@@ -25,21 +22,8 @@ class EmptyPipelineComponent(PipelineComponent):
         anystr_strip_whitespace = True
 
 
-# schema_type does not exist
-class PipelineComponentNoSchemaType(EmptyPipelineComponent):
-    type: str = "pipeline-component-no-schema-type"
-
-
 class SubPipelineComponent(EmptyPipelineComponent):
-    type: str = "sub-pipeline-component"
-    schema_type: Literal["sub-pipeline-component"] = Field(
-        default="sub-pipeline-component", exclude=True
-    )
-
-
-# schema_type is inherited from SubPipelineComponent
-class SubPipelineComponentNoSchemaType(SubPipelineComponent):
-    type: str = "sub-pipeline-component-no-schema-type"
+    type = "sub-pipeline-component"
 
 
 # schema_type and type are inherited from SubPipelineComponent
@@ -47,46 +31,9 @@ class SubPipelineComponentNoSchemaTypeNoType(SubPipelineComponent):
     ...
 
 
-# schema_type not Literal
-class SubPipelineComponentBadSchemaTypeDef(SubPipelineComponent):
-    type: str = "sub-pipeline-component-bad-schema-type-def"
-    schema_type: str = "sub-pipeline-component-bad-schema-type-def"
-
-
-# schema_type Literal arg not same as default value
-class SubPipelineComponentBadSchemaTypeNoMatchDefault(SubPipelineComponent):
-    type: str = "sub-pipeline-component-bad-schema-type-no-match-default"
-    schema_type: Literal[
-        "sub-pipeline-component-bad-schema-type-no-match-default-NO-MATCH"
-    ] = Field(
-        default="sub-pipeline-component-bad-schema-type-no-match-default", exclude=True
-    )
-
-
-# schema_type not matching type
-class SubPipelineComponentBadSchemaTypeDefNotMatching(SubPipelineComponent):
-    type: str = "sub-pipeline-component-not-matching"
-    schema_type: Literal[
-        "sub-pipeline-component-bad-schema-type-def-not-matching"
-    ] = Field(
-        default="sub-pipeline-component-bad-schema-type-def-not-matching", exclude=True
-    )
-
-
-# schema_type no default
-class SubPipelineComponentBadSchemaTypeMissingDefault(SubPipelineComponent):
-    type: str = "sub-pipeline-component-bad-schema-type-default-not-set"
-    schema_type: Literal[
-        "sub-pipeline-component-bad-schema-type-default-not-set"
-    ] = Field(exclude=True)
-
-
 # Correctly defined
 class SubPipelineComponentCorrect(SubPipelineComponent):
-    type: str = "sub-pipeline-component-correct"
-    schema_type: Literal["sub-pipeline-component-correct"] = Field(
-        default="sub-pipeline-component-correct", exclude=True
-    )
+    type = "sub-pipeline-component-correct"
 
 
 # Correctly defined, docstr test
@@ -116,16 +63,7 @@ class SubPipelineComponentCorrectDocstr(SubPipelineComponent):
     :param error_marker: error_marker
     """
 
-    type: str = Field(
-        default="sub-pipeline-component-correct-docstr",
-        description=describe_attr("type", __doc__),
-        const=True,
-    )
-    schema_type: Literal["sub-pipeline-component-correct-docstr"] = Field(
-        default="sub-pipeline-component-correct-docstr",
-        description=describe_object(__doc__),
-        exclude=True,
-    )
+    type = "sub-pipeline-component-correct-docstr"
 
 
 MODULE = EmptyPipelineComponent.__module__

--- a/tests/cli/test_schema_generation.py
+++ b/tests/cli/test_schema_generation.py
@@ -16,7 +16,7 @@ RESOURCE_PATH = Path(__file__).parent / "resources"
 runner = CliRunner()
 
 
-# schema_type and type not defined
+# type is inherited from PipelineComponent
 class EmptyPipelineComponent(PipelineComponent):
     class Config:
         anystr_strip_whitespace = True
@@ -26,7 +26,7 @@ class SubPipelineComponent(EmptyPipelineComponent):
     type = "sub-pipeline-component"
 
 
-# schema_type and type are inherited from SubPipelineComponent
+# type is inherited from SubPipelineComponent
 class SubPipelineComponentNoSchemaTypeNoType(SubPipelineComponent):
     ...
 
@@ -57,9 +57,6 @@ class SubPipelineComponentCorrectDocstr(SubPipelineComponent):
         if error_marker is found in result.stdout, the description extraction does
         not work correctly.,!?:error_marker   :: "!$%
     :type type: This line should not appear anywhere error_marker
-    :param schema_type: This description should not be applied to schema_type as
-        it instead reads the class description. error_marker
-    :type schema_type: This line should not appear anywhere error_marker
     :param error_marker: error_marker
     """
 


### PR DESCRIPTION
manually defining component `schema_type` is no longer necessary

component type can be set without using `pydantic.Field`
```python
class CustomComponent(PipelineComponent):
    type = "custom-component"
```