### PR TITLE
Set default for ToSection topics

### DIFF
--- a/docs/docs/resources/pipeline-components/kafka-app.yaml
+++ b/docs/docs/resources/pipeline-components/kafka-app.yaml
@@ -10,13 +10,13 @@
       brokers: ${brokers} # required
       schemaRegistryUrl: ${schema_registry_url}
     nameOverride: override-with-this-name # kafka-app-specific
-    imageTag: "1.0.0" # Example values that are shared between streams-app and producer-app 
+    imageTag: "1.0.0" # Example values that are shared between streams-app and producer-app
   # Topic(s) from which the component will read input
   # from: # Not advised to ever be used in `kafka-app` as it isn't supported by
   # `producer`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -25,11 +25,11 @@
         valueSchema: value-schema
         partitions_count: 1
         replication_factor: 1
-        configs: 
+        configs:
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration, the default value is given here

--- a/docs/docs/resources/pipeline-components/kafka-connector.yaml
+++ b/docs/docs/resources/pipeline-components/kafka-connector.yaml
@@ -8,13 +8,13 @@
     tasks.max: 1
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: error # required
         keySchema: key-schema # must implement SchemaProvider to use
@@ -25,14 +25,14 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration for resetter
   repoConfig:
     repositoryName: my-repo # required
     url: https://bakdata.github.io/kafka-connect-resetter/ # required
-    repoAuthFlags: 
+    repoAuthFlags:
       username: user
       password: pass
       ca_file: /home/user/path/to/ca-file

--- a/docs/docs/resources/pipeline-components/kafka-sink-connector.yaml
+++ b/docs/docs/resources/pipeline-components/kafka-sink-connector.yaml
@@ -9,7 +9,7 @@
     tasks.max: 1
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra`

--- a/docs/docs/resources/pipeline-components/kafka-source-connector.yaml
+++ b/docs/docs/resources/pipeline-components/kafka-source-connector.yaml
@@ -10,7 +10,7 @@
     errors.tolerance: none
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -22,14 +22,14 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration
   repoConfig:
     repositoryName: my-repo # required
     url: https://bakdata.github.io/kafka-connect-resetter/ # required
-    repoAuthFlags: 
+    repoAuthFlags:
       username: user
       password: pass
       ca_file: /home/user/path/to/ca-file

--- a/docs/docs/resources/pipeline-components/kubernetes-app.yaml
+++ b/docs/docs/resources/pipeline-components/kubernetes-app.yaml
@@ -10,7 +10,7 @@
     commandLine: {} # Example
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra` or `extra-pattern`

--- a/docs/docs/resources/pipeline-components/pipeline.yaml
+++ b/docs/docs/resources/pipeline-components/pipeline.yaml
@@ -10,13 +10,13 @@
     commandLine: {} # Example
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra` or `extra-pattern`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -28,14 +28,14 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration
   repoConfig:
     repositoryName: my-repo # required
     url: https://bakdata.github.io/ # required
-    repoAuthFlags: 
+    repoAuthFlags:
       username: user
       password: pass
       ca_file: /home/user/path/to/ca-file
@@ -59,7 +59,7 @@
   # `producer`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -68,11 +68,11 @@
         valueSchema: value-schema
         partitions_count: 1
         replication_factor: 1
-        configs: 
+        configs:
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration, the default value is given here
@@ -112,11 +112,11 @@
           - input_topic4
       extraInputPatterns:
         pattern_role1: input_pattern1
-      extraOutputTopics: 
+      extraOutputTopics:
         output_role1: output_topic1
         output_role2: output_topic2
       errorTopic: error-topic
-      config: 
+      config:
         my.streams.config: my.value
     nameOverride: override-with-this-name # streams-app-specific
     autoscaling: # streams-app-specific
@@ -148,13 +148,13 @@
         - topic2
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra` or `extra-pattern`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -162,11 +162,11 @@
         valueSchema: value-schema
         partitions_count: 1
         replication_factor: 1
-        configs: 
+        configs:
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration, the default value is given here
@@ -193,13 +193,13 @@
       brokers: ${brokers} # required
       schemaRegistryUrl: ${schema_registry_url}
       outputTopic: output_topic
-      extraOutputTopics: 
+      extraOutputTopics:
         output_role1: output_topic1
         output_role2: output_topic2
     nameOverride: override-with-this-name # kafka-app-specific
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -211,7 +211,7 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration, the default value is given here
@@ -236,7 +236,7 @@
     errors.tolerance: none
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -248,14 +248,14 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration
   repoConfig:
     repositoryName: my-repo # required
     url: https://bakdata.github.io/kafka-connect-resetter/ # required
-    repoAuthFlags: 
+    repoAuthFlags:
       username: user
       password: pass
       ca_file: /home/user/path/to/ca-file
@@ -279,13 +279,13 @@
     tasks.max: 1
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra`
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: error # required
         keySchema: key-schema # must implement SchemaProvider to use
@@ -296,14 +296,14 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration for resetter
   repoConfig:
     repositoryName: my-repo # required
     url: https://bakdata.github.io/kafka-connect-resetter/ # required
-    repoAuthFlags: 
+    repoAuthFlags:
       username: user
       password: pass
       ca_file: /home/user/path/to/ca-file

--- a/docs/docs/resources/pipeline-components/producer.yaml
+++ b/docs/docs/resources/pipeline-components/producer.yaml
@@ -12,13 +12,13 @@
       brokers: ${brokers} # required
       schemaRegistryUrl: ${schema_registry_url}
       outputTopic: output_topic
-      extraOutputTopics: 
+      extraOutputTopics:
         output_role1: output_topic1
         output_role2: output_topic2
     nameOverride: override-with-this-name # kafka-app-specific
   # Topic(s) into which the component will write output
   to:
-    topics: # required
+    topics:
       ${pipeline_name}-output-topic:
         type: output # required
         # role: topic-role # only used if type is `extra`
@@ -30,7 +30,7 @@
           cleanup.policy: compact
     models: # SchemaProvider is initiated with the values given here
       model: model
-  # Pipeline prefix that will prefix every component name. If you wish to not 
+  # Pipeline prefix that will prefix every component name. If you wish to not
   # have any prefix you can specify an empty string.
   prefix: ${pipeline_name}-
   # Helm repository configuration, the default value is given here

--- a/docs/docs/resources/pipeline-components/streams-app.yaml
+++ b/docs/docs/resources/pipeline-components/streams-app.yaml
@@ -61,7 +61,7 @@
         - topic2
   # Topic(s) from which the component will read input
   from:
-    topics: # required
+    topics:
       ${pipeline_name}-input-topic:
         type: input # required
         # role: topic-role # only used if type is `extra` or `extra-pattern`

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -1164,14 +1164,12 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/TopicConfig"
                     },
+                    "default": {},
                     "description": "Output topics",
                     "title": "Topics",
                     "type": "object"
                 }
             },
-            "required": [
-                "topics"
-            ],
             "title": "ToSection",
             "type": "object"
         },

--- a/kpops/components/base_components/models/to_section.py
+++ b/kpops/components/base_components/models/to_section.py
@@ -79,10 +79,8 @@ class TopicConfig(BaseModel):
 class ToSection(BaseModel):
     """Holds multiple output topics
 
-    :param models: Data models
-    :type models: dict[str, Any]
     :param topics: Output topics
-    :type topics: dict[str, TopicConfig]
+    :param models: Data models
     """
 
     # TODO: really multiple models?

--- a/kpops/components/base_components/models/to_section.py
+++ b/kpops/components/base_components/models/to_section.py
@@ -87,11 +87,11 @@ class ToSection(BaseModel):
 
     # TODO: really multiple models?
     # any because snapshot versions must be supported
+    topics: dict[TopicName, TopicConfig] = Field(
+        default={}, description=describe_attr("topics", __doc__)
+    )
     models: dict[str, Any] = Field(
         default={}, description=describe_attr("models", __doc__)
-    )
-    topics: dict[TopicName, TopicConfig] = Field(
-        ..., description=describe_attr("topics", __doc__)
     )
 
     class Config(DescConfig):

--- a/kpops/components/base_components/models/to_section.py
+++ b/kpops/components/base_components/models/to_section.py
@@ -83,11 +83,11 @@ class ToSection(BaseModel):
     :param models: Data models
     """
 
-    # TODO: really multiple models?
-    # any because snapshot versions must be supported
     topics: dict[TopicName, TopicConfig] = Field(
         default={}, description=describe_attr("topics", __doc__)
     )
+    # TODO: really multiple models?
+    # any because snapshot versions must be supported
     models: dict[str, Any] = Field(
         default={}, description=describe_attr("models", __doc__)
     )

--- a/tests/cli/snapshots/snap_test_schema_generation.py
+++ b/tests/cli/snapshots/snap_test_schema_generation.py
@@ -306,14 +306,12 @@ snapshots['TestGenSchema.test_gen_pipeline_schema_only_custom_module test-schema
                     "additionalProperties": {
                         "$ref": "#/definitions/TopicConfig"
                     },
+                    "default": {},
                     "description": "Output topics",
                     "title": "Topics",
                     "type": "object"
                 }
             },
-            "required": [
-                "topics"
-            ],
             "title": "ToSection",
             "type": "object"
         },


### PR DESCRIPTION
allow configuring empty ToSection more easily without having to specify topics attribute, same as FromSection

```yaml
- type: kubernetes-app
  name: example
  from: {}
  to: {}
```