### PR TITLE
Fix GitHub action error in non-Python projects

### DIFF
--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -51,7 +51,7 @@ runs:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.token }}
 
-    - run: echo "kpops"${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }} > $RUNNER_TEMP/requirements.txt
+    - run: echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > $RUNNER_TEMP/requirements.txt
       shell: bash
 
     - name: Set up Python ${{ inputs.python-version }}
@@ -59,13 +59,13 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
-        cache-dependency-path: ${{ env.RUNNER_TEMP }}/requirements.txt
+        cache-dependency-path: $RUNNER_TEMP/requirements.txt
 
     - name: Install KPOps
       shell: bash
       run: |
         echo "::group::install kpops package"
-        pip install -r ${{ env.RUNNER_TEMP }}/requirements.txt
+        pip install -r $RUNNER_TEMP/requirements.txt
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -51,8 +51,12 @@ runs:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.token }}
 
-    - run: echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > $RUNNER_TEMP/requirements.txt
+    - name: Create temporary requirements.txt for caching
       shell: bash
+      run: |
+        TEMP_FILE="$RUNNER_TEMP/requirements.txt"
+        echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > "$TEMP_FILE"
+        cat "$TEMP_FILE"
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -50,7 +50,7 @@ runs:
     - name: Install KPOps
       shell: bash
       run: |
-        echo "::group::pip install kpops package"
+        echo "::group::install kpops package"
         pipx install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
         echo "::endgroup::"
 

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -47,6 +47,12 @@ runs:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.token }}
 
+    - name: Cache pipx
+      uses: actions/cache@v3
+      with:
+        path: ~/.local/pipx/venvs
+        key: pipx-${{ runner.os }}-${{ inputs.kpops-version }}
+
     - name: Install KPOps
       shell: bash
       run: |

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -55,7 +55,7 @@ runs:
       shell: bash
       id: requirements
       run: |
-        TEMP_FILE="kpops-runner-action-requirements.txt"
+        TEMP_FILE="${{ github.action_path }}/kpops-runner-action-requirements.txt"
         echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > "$TEMP_FILE"
         cat "$TEMP_FILE"
         echo  "path=$TEMP_FILE">> $GITHUB_OUTPUT
@@ -65,8 +65,9 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
-        cache-dependency-path: |
-          "${{ steps.requirements.outputs.path }}"
+        cache-dependency-path: ''
+        # FIXME: https://github.com/actions/setup-python/issues/361
+        # "${{ steps.requirements.outputs.path }}"
 
     - name: Install KPOps
       shell: bash

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -26,10 +26,6 @@ inputs:
   filter-type:
     description: "Whether to include/exclude the steps defined in KPOPS_PIPELINE_STEPS (default is include)"
     required: false
-  python-version:
-    description: "Python version to install (Defaults to the latest stable version of Python 3.11)"
-    required: false
-    default: "3.11.x"
   kpops-version:
     description: "KPOps version"
     required: false
@@ -45,12 +41,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-
     - name: Set up Helm
       uses: azure/setup-helm@v3
       with:
@@ -61,7 +51,7 @@ runs:
       shell: bash
       run: |
         echo "::group::pip install kpops package"
-        pip install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
+        pipx install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -45,29 +45,27 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-
     - name: Set up Helm
       uses: azure/setup-helm@v3
       with:
         version: ${{ inputs.helm-version }}
         token: ${{ inputs.token }}
 
-    - name: Cache pipx
-      uses: actions/cache@v3
+    - run: echo "kpops"${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }} > $RUNNER_TEMP/requirements.txt
+      shell: bash
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
       with:
-        path: ~/.local/pipx/venvs
-        key: pipx-${{ runner.os }}-${{ inputs.kpops-version }}
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: ${{ env.RUNNER_TEMP }}/requirements.txt
 
     - name: Install KPOps
       shell: bash
       run: |
         echo "::group::install kpops package"
-        pip install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
+        pip install -r ${{ env.RUNNER_TEMP }}/requirements.txt
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -64,13 +64,13 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: pip
         cache-dependency-path: |
-          $RUNNER_TEMP/requirements.txt
+          "$RUNNER_TEMP/requirements.txt"
 
     - name: Install KPOps
       shell: bash
       run: |
         echo "::group::install kpops package"
-        pip install -r $RUNNER_TEMP/requirements.txt
+        pip install -r "$RUNNER_TEMP/requirements.txt"
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -53,10 +53,13 @@ runs:
 
     - name: Create temporary requirements.txt for caching
       shell: bash
+      id: requirements
       run: |
         TEMP_FILE="$RUNNER_TEMP/requirements.txt"
         echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > "$TEMP_FILE"
         cat "$TEMP_FILE"
+        echo  "path=$TEMP_FILE">> $GITHUB_OUTPUT
+
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4
@@ -64,13 +67,13 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: pip
         cache-dependency-path: |
-          "$RUNNER_TEMP/requirements.txt"
+          "${{ steps.requirements.outputs.path }}"
 
     - name: Install KPOps
       shell: bash
       run: |
         echo "::group::install kpops package"
-        pip install -r "$RUNNER_TEMP/requirements.txt"
+        pip install -r "${{ steps.requirements.outputs.path }}"
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -60,7 +60,6 @@ runs:
         cat "$TEMP_FILE"
         echo  "path=$TEMP_FILE">> $GITHUB_OUTPUT
 
-
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -59,7 +59,8 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
-        cache-dependency-path: $RUNNER_TEMP/requirements.txt
+        cache-dependency-path: |
+          $RUNNER_TEMP/requirements.txt
 
     - name: Install KPOps
       shell: bash

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -26,6 +26,10 @@ inputs:
   filter-type:
     description: "Whether to include/exclude the steps defined in KPOPS_PIPELINE_STEPS (default is include)"
     required: false
+  python-version:
+    description: "Python version to install (Defaults to the latest stable version of Python 3.11)"
+    required: false
+    default: "3.11.x"
   kpops-version:
     description: "KPOps version"
     required: false
@@ -41,6 +45,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
     - name: Set up Helm
       uses: azure/setup-helm@v3
       with:
@@ -57,7 +67,7 @@ runs:
       shell: bash
       run: |
         echo "::group::install kpops package"
-        pipx install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
+        pip install kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}
         echo "::endgroup::"
 
     - name: ${{ inputs.command }} ${{ inputs.pipeline }} pipeline

--- a/actions/kpops-runner/action.yaml
+++ b/actions/kpops-runner/action.yaml
@@ -55,7 +55,7 @@ runs:
       shell: bash
       id: requirements
       run: |
-        TEMP_FILE="$RUNNER_TEMP/requirements.txt"
+        TEMP_FILE="kpops-runner-action-requirements.txt"
         echo "kpops${{ inputs.kpops-version != 'latest' && format('=={0}', inputs.kpops-version) || '' }}" > "$TEMP_FILE"
         cat "$TEMP_FILE"
         echo  "path=$TEMP_FILE">> $GITHUB_OUTPUT

--- a/docs/docs/user/references/ci-integration/github-actions.md
+++ b/docs/docs/user/references/ci-integration/github-actions.md
@@ -16,7 +16,6 @@ that installs all the necessary dependencies and runs KPOps commands with the gi
 | config            |    ❌    |       -       | string | config.yaml file path                                                                                                                         |
 | components        |    ❌    |       -       | string | components package path                                                                                                                       |
 | filter-type       |    ❌    |       -       | string | Whether to include/exclude the steps defined in KPOPS_PIPELINE_STEPS                                                                          |
-| python-version    |    ❌    |   "3.11.x"    | string | Python version to install (Defaults to the latest stable version of Python 3.11)                                                              |
 | kpops-version     |    ❌    |    latest     | string | KPOps version to install                                                                                                                      |
 | helm-version      |    ❌    |    latest     | string | Helm version to install                                                                                                                       |
 | token             |    ❌    |    latest     | string | secrets.GITHUB_TOKEN, needed for setup-helm action if helm-version is set to latest                                                           |

--- a/docs/docs/user/references/ci-integration/github-actions.md
+++ b/docs/docs/user/references/ci-integration/github-actions.md
@@ -16,6 +16,7 @@ that installs all the necessary dependencies and runs KPOps commands with the gi
 | config            |    ❌    |       -       | string | config.yaml file path                                                                                                                         |
 | components        |    ❌    |       -       | string | components package path                                                                                                                       |
 | filter-type       |    ❌    |       -       | string | Whether to include/exclude the steps defined in KPOPS_PIPELINE_STEPS                                                                          |
+| python-version    |    ❌    |   "3.11.x"    | string | Python version to install (Defaults to the latest stable version of Python 3.11)                                                              |
 | kpops-version     |    ❌    |    latest     | string | KPOps version to install                                                                                                                      |
 | helm-version      |    ❌    |    latest     | string | Helm version to install                                                                                                                       |
 | token             |    ❌    |    latest     | string | secrets.GITHUB_TOKEN, needed for setup-helm action if helm-version is set to latest                                                           |


### PR DESCRIPTION
Fixes error when running in a deployment repo that doesn't contain a Python project

> No file in /home/runner/work/repo matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository

~~downside of removing the `setup-python` action is that it will only work on GitHub runners that have Python and pipx pre-installed, e.g. the standard ubuntu runners. I don't see a reason why someone would want to use a different runner for deploying with KPOps~~

contains first steps towards caching kpops package installation but is currently blocked by https://github.com/actions/setup-python/issues/361