### PR TITLE
Fix GitHub ref variable for pushing docs to main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,12 +86,10 @@ jobs:
   
   publish-docs-from-main:
     runs-on: ubuntu-22.04
-    if: ${{ github.head_ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [test]
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       
       - name: Publish docs from main branch
         uses: ./.github/actions/update-docs


### PR DESCRIPTION
According to the [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context):

> The `head_ref` or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`.

So we remove the `head_ref` and replace it with `ref`:

> The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by `pull_request`, this is the pull request merge branch. For workflows triggered by release, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is `refs/heads/<branch_name>`, for pull requests it is `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`. For example, `refs/heads/feature-branch-1`.

Second option: This can be also replaced with `ref_name`:

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, `feature-branch-1`.