### PR TITLE
Refactor Helm `nameOverride`

### DIFF
--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -66,7 +66,7 @@
                 "app": {
                     "allOf": [
                         {
-                            "$ref": "#/$defs/HelmAppConfig"
+                            "$ref": "#/$defs/HelmAppValues"
                         }
                     ],
                     "description": "Helm app values"
@@ -146,7 +146,7 @@
             "title": "HelmApp",
             "type": "object"
         },
-        "HelmAppConfig": {
+        "HelmAppValues": {
             "additionalProperties": true,
             "description": "",
             "properties": {
@@ -163,7 +163,7 @@
                     "title": "Nameoverride"
                 }
             },
-            "title": "HelmAppConfig",
+            "title": "HelmAppValues",
             "type": "object"
         },
         "HelmRepoConfig": {
@@ -456,7 +456,7 @@
                 "app": {
                     "allOf": [
                         {
-                            "$ref": "#/$defs/ProducerValues"
+                            "$ref": "#/$defs/ProducerAppValues"
                         }
                     ],
                     "description": "Application-specific settings"
@@ -536,6 +536,37 @@
             "title": "ProducerApp",
             "type": "object"
         },
+        "ProducerAppValues": {
+            "additionalProperties": true,
+            "description": "Settings specific to producers.",
+            "properties": {
+                "nameOverride": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Nameoverride"
+                },
+                "streams": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/ProducerStreamsConfig"
+                        }
+                    ],
+                    "description": "Kafka Streams settings"
+                }
+            },
+            "required": [
+                "streams"
+            ],
+            "title": "ProducerAppValues",
+            "type": "object"
+        },
         "ProducerStreamsConfig": {
             "additionalProperties": true,
             "description": "Kafka Streams settings specific to Producer.",
@@ -585,37 +616,6 @@
                 "brokers"
             ],
             "title": "ProducerStreamsConfig",
-            "type": "object"
-        },
-        "ProducerValues": {
-            "additionalProperties": true,
-            "description": "Settings specific to producers.",
-            "properties": {
-                "nameOverride": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Nameoverride"
-                },
-                "streams": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/ProducerStreamsConfig"
-                        }
-                    ],
-                    "description": "Kafka Streams settings"
-                }
-            },
-            "required": [
-                "streams"
-            ],
-            "title": "ProducerValues",
             "type": "object"
         },
         "RepoAuthFlags": {
@@ -692,7 +692,7 @@
                 "app": {
                     "allOf": [
                         {
-                            "$ref": "#/$defs/StreamsAppConfig"
+                            "$ref": "#/$defs/StreamsAppValues"
                         }
                     ],
                     "description": "Application-specific settings"
@@ -859,7 +859,7 @@
             "title": "StreamsAppAutoScaling",
             "type": "object"
         },
-        "StreamsAppConfig": {
+        "StreamsAppValues": {
             "additionalProperties": true,
             "description": "StreamsBoostrap app configurations.\nThe attributes correspond to keys and values that are used as values for the streams bootstrap helm chart.",
             "properties": {
@@ -899,7 +899,7 @@
             "required": [
                 "streams"
             ],
-            "title": "StreamsAppConfig",
+            "title": "StreamsAppValues",
             "type": "object"
         },
         "StreamsConfig": {

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -66,10 +66,10 @@
                 "app": {
                     "allOf": [
                         {
-                            "$ref": "#/$defs/KubernetesAppConfig"
+                            "$ref": "#/$defs/HelmAppConfig"
                         }
                     ],
-                    "description": "Application-specific settings"
+                    "description": "Helm app values"
                 },
                 "from": {
                     "anyOf": [
@@ -144,6 +144,26 @@
                 "app"
             ],
             "title": "HelmApp",
+            "type": "object"
+        },
+        "HelmAppConfig": {
+            "additionalProperties": true,
+            "description": "",
+            "properties": {
+                "nameOverride": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Nameoverride"
+                }
+            },
+            "title": "HelmAppConfig",
             "type": "object"
         },
         "HelmRepoConfig": {
@@ -420,13 +440,6 @@
             "title": "KafkaSourceConnector",
             "type": "object"
         },
-        "KubernetesAppConfig": {
-            "additionalProperties": true,
-            "description": "Settings specific to Kubernetes apps.",
-            "properties": {},
-            "title": "KubernetesAppConfig",
-            "type": "object"
-        },
         "OutputTopicTypes": {
             "description": "Types of output topic.\n\nOUTPUT (output topic), ERROR (error topic)",
             "enum": [
@@ -588,7 +601,6 @@
                         }
                     ],
                     "default": null,
-                    "description": "Override name with this value",
                     "title": "Nameoverride"
                 },
                 "streams": {
@@ -873,7 +885,6 @@
                         }
                     ],
                     "default": null,
-                    "description": "Override name with this value",
                     "title": "Nameoverride"
                 },
                 "streams": {

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -11,6 +11,7 @@ from pydantic import (
 from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import override
 
+from kpops.components.base_components.helm_app import HelmAppValues
 from kpops.utils.pydantic import (
     CamelCaseConfigModel,
     DescConfigModel,
@@ -99,14 +100,6 @@ class KafkaConnectResetterConfig(CamelCaseConfigModel):
     offset_topic: str | None = None
 
 
-class KafkaConnectResetterValues(CamelCaseConfigModel):
+class KafkaConnectResetterValues(HelmAppValues):
     connector_type: Literal["source", "sink"]
     config: KafkaConnectResetterConfig
-    name_override: str
-
-    # TODO(Ivan Yordanov): Replace with a function decorated with `@model_serializer`
-    # BEWARE! All default values are enforced, hard to replicate without
-    # access to ``model_dump``
-    @override
-    def model_dump(self, **_) -> dict[str, Any]:
-        return super().model_dump(by_alias=True, exclude_none=True)

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -93,13 +93,13 @@ class KafkaConnectConfigErrorResponse(BaseModel):
     configs: list[KafkaConnectConfigDescription]
 
 
-class KafkaConnectResetterConfig(CamelCaseConfigModel):
+class KafkaConnectorResetterConfig(CamelCaseConfigModel):
     brokers: str
     connector: str
     delete_consumer_group: bool | None = None
     offset_topic: str | None = None
 
 
-class KafkaConnectResetterValues(HelmAppValues):
+class KafkaConnectorResetterValues(HelmAppValues):
     connector_type: Literal["source", "sink"]
-    config: KafkaConnectResetterConfig
+    config: KafkaConnectorResetterConfig

--- a/kpops/components/base_components/helm_app.py
+++ b/kpops/components/base_components/helm_app.py
@@ -30,6 +30,15 @@ log = logging.getLogger("HelmApp")
 class HelmAppValues(KubernetesAppValues):
     name_override: str | None = None
 
+    # TODO(Ivan Yordanov): Replace with a function decorated with `@model_serializer`
+    # BEWARE! All default values are enforced, hard to replicate without
+    # access to ``model_dump``
+    @override
+    def model_dump(self, **_) -> dict[str, Any]:
+        return super().model_dump(
+            by_alias=True, exclude_none=True, exclude_defaults=True
+        )
+
 
 class HelmApp(KubernetesApp):
     """Kubernetes app managed through Helm with an associated Helm chart.
@@ -156,9 +165,7 @@ class HelmApp(KubernetesApp):
         """
         if self.app.name_override is None:
             self.app.name_override = self.full_name
-        return self.app.model_dump(
-            by_alias=True, exclude_none=True, exclude_defaults=True
-        )
+        return self.app.model_dump()
 
     def print_helm_diff(self, stdout: str) -> None:
         """Print the diff of the last and current release of this component.

--- a/kpops/components/base_components/helm_app.py
+++ b/kpops/components/base_components/helm_app.py
@@ -16,12 +16,19 @@ from kpops.component_handlers.helm_wrapper.model import (
     HelmTemplateFlags,
     HelmUpgradeInstallFlags,
 )
-from kpops.components.base_components.kubernetes_app import KubernetesApp
+from kpops.components.base_components.kubernetes_app import (
+    KubernetesApp,
+    KubernetesAppConfig,
+)
 from kpops.utils.colorify import magentaify
 from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import exclude_by_name
 
 log = logging.getLogger("HelmApp")
+
+
+class HelmAppConfig(KubernetesAppConfig):  # TODO: rename HelmAppValues
+    name_override: str | None = None
 
 
 class HelmApp(KubernetesApp):
@@ -31,6 +38,7 @@ class HelmApp(KubernetesApp):
         deploying the component, defaults to None this means that the command "helm repo add" is not called and Helm
         expects a path to local Helm chart.
     :param version: Helm chart version, defaults to None
+    :param app: Helm app values
     """
 
     repo_config: HelmRepoConfig | None = Field(
@@ -40,6 +48,10 @@ class HelmApp(KubernetesApp):
     version: str | None = Field(
         default=None,
         description=describe_attr("version", __doc__),
+    )
+    app: HelmAppConfig = Field(
+        default=...,
+        description=describe_attr("app", __doc__),
     )
 
     @cached_property
@@ -142,6 +154,8 @@ class HelmApp(KubernetesApp):
 
         :returns: Thte values to be used by Helm
         """
+        if self.app.name_override is None:
+            self.app.name_override = self.full_name
         return self.app.model_dump(
             by_alias=True, exclude_none=True, exclude_defaults=True
         )

--- a/kpops/components/base_components/helm_app.py
+++ b/kpops/components/base_components/helm_app.py
@@ -18,7 +18,7 @@ from kpops.component_handlers.helm_wrapper.model import (
 )
 from kpops.components.base_components.kubernetes_app import (
     KubernetesApp,
-    KubernetesAppConfig,
+    KubernetesAppValues,
 )
 from kpops.utils.colorify import magentaify
 from kpops.utils.docstring import describe_attr
@@ -27,7 +27,7 @@ from kpops.utils.pydantic import exclude_by_name
 log = logging.getLogger("HelmApp")
 
 
-class HelmAppConfig(KubernetesAppConfig):  # TODO: rename HelmAppValues
+class HelmAppValues(KubernetesAppValues):
     name_override: str | None = None
 
 
@@ -49,7 +49,7 @@ class HelmApp(KubernetesApp):
         default=None,
         description=describe_attr("version", __doc__),
     )
-    app: HelmAppConfig = Field(
+    app: HelmAppValues = Field(
         default=...,
         description=describe_attr("app", __doc__),
     )

--- a/kpops/components/base_components/kafka_app.py
+++ b/kpops/components/base_components/kafka_app.py
@@ -11,8 +11,7 @@ from kpops.component_handlers.helm_wrapper.model import (
     HelmUpgradeInstallFlags,
 )
 from kpops.component_handlers.helm_wrapper.utils import trim_release_name
-from kpops.components.base_components.helm_app import HelmApp
-from kpops.components.base_components.kubernetes_app import KubernetesAppConfig
+from kpops.components.base_components.helm_app import HelmApp, HelmAppConfig
 from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfigModel, DescConfigModel
 
@@ -36,18 +35,14 @@ class KafkaStreamsConfig(CamelCaseConfigModel, DescConfigModel):
     )
 
 
-class KafkaAppConfig(KubernetesAppConfig):
+class KafkaAppConfig(HelmAppConfig):
     """Settings specific to Kafka Apps.
 
     :param streams: Kafka streams config
-    :param name_override: Override name with this value, defaults to None
     """
 
     streams: KafkaStreamsConfig = Field(
         default=..., description=describe_attr("streams", __doc__)
-    )
-    name_override: str | None = Field(
-        default=None, description=describe_attr("name_override", __doc__)
     )
 
 

--- a/kpops/components/base_components/kafka_app.py
+++ b/kpops/components/base_components/kafka_app.py
@@ -11,7 +11,7 @@ from kpops.component_handlers.helm_wrapper.model import (
     HelmUpgradeInstallFlags,
 )
 from kpops.component_handlers.helm_wrapper.utils import trim_release_name
-from kpops.components.base_components.helm_app import HelmApp, HelmAppConfig
+from kpops.components.base_components.helm_app import HelmApp, HelmAppValues
 from kpops.utils.docstring import describe_attr
 from kpops.utils.pydantic import CamelCaseConfigModel, DescConfigModel
 
@@ -35,7 +35,7 @@ class KafkaStreamsConfig(CamelCaseConfigModel, DescConfigModel):
     )
 
 
-class KafkaAppConfig(HelmAppConfig):
+class KafkaAppValues(HelmAppValues):
     """Settings specific to Kafka Apps.
 
     :param streams: Kafka streams config
@@ -58,7 +58,7 @@ class KafkaApp(HelmApp, ABC):
     :param version: Helm chart version, defaults to "2.9.0"
     """
 
-    app: KafkaAppConfig = Field(
+    app: KafkaAppValues = Field(
         default=...,
         description=describe_attr("app", __doc__),
     )

--- a/kpops/components/base_components/kafka_connector.py
+++ b/kpops/components/base_components/kafka_connector.py
@@ -20,9 +20,9 @@ from kpops.component_handlers.helm_wrapper.model import (
 from kpops.component_handlers.helm_wrapper.utils import trim_release_name
 from kpops.component_handlers.kafka_connect.model import (
     KafkaConnectorConfig,
+    KafkaConnectorResetterConfig,
+    KafkaConnectorResetterValues,
     KafkaConnectorType,
-    KafkaConnectResetterConfig,
-    KafkaConnectResetterValues,
 )
 from kpops.components.base_components.base_defaults_component import deduplicate
 from kpops.components.base_components.models.from_section import FromTopic
@@ -176,7 +176,7 @@ class KafkaConnector(PipelineComponent, ABC):
 
         :param dry_run: If the cleanup should be run in dry run mode or not
         :param retain_clean_jobs: If the cleanup job should be kept
-        :param kwargs: Other values for the KafkaConnectResetter
+        :param kwargs: Other values for the KafkaConnectorResetter
         """
         log.info(
             magentaify(
@@ -237,8 +237,8 @@ class KafkaConnector(PipelineComponent, ABC):
         :return: The Helm chart values of the connector resetter
         """
         return {
-            **KafkaConnectResetterValues(
-                config=KafkaConnectResetterConfig(
+            **KafkaConnectorResetterValues(
+                config=KafkaConnectorResetterConfig(
                     connector=self.full_name,
                     brokers=self.config.kafka_brokers,
                     **kwargs,

--- a/kpops/components/base_components/kubernetes_app.py
+++ b/kpops/components/base_components/kubernetes_app.py
@@ -18,7 +18,7 @@ KUBERNETES_NAME_CHECK_PATTERN = re.compile(
 )
 
 
-class KubernetesAppConfig(CamelCaseConfigModel, DescConfigModel):
+class KubernetesAppValues(CamelCaseConfigModel, DescConfigModel):
     """Settings specific to Kubernetes apps."""
 
     model_config = ConfigDict(
@@ -39,7 +39,7 @@ class KubernetesApp(PipelineComponent, ABC):
         default=...,
         description=describe_attr("namespace", __doc__),
     )
-    app: KubernetesAppConfig = Field(
+    app: KubernetesAppValues = Field(
         default=...,
         description=describe_attr("app", __doc__),
     )

--- a/kpops/components/streams_bootstrap/producer/model.py
+++ b/kpops/components/streams_bootstrap/producer/model.py
@@ -1,7 +1,7 @@
 from pydantic import ConfigDict, Field
 
 from kpops.components.base_components.kafka_app import (
-    KafkaAppConfig,
+    KafkaAppValues,
     KafkaStreamsConfig,
 )
 from kpops.utils.docstring import describe_attr
@@ -22,7 +22,7 @@ class ProducerStreamsConfig(KafkaStreamsConfig):
     )
 
 
-class ProducerValues(KafkaAppConfig):
+class ProducerAppValues(KafkaAppValues):
     """Settings specific to producers.
 
     :param streams: Kafka Streams settings

--- a/kpops/components/streams_bootstrap/producer/producer_app.py
+++ b/kpops/components/streams_bootstrap/producer/producer_app.py
@@ -9,7 +9,7 @@ from kpops.components.base_components.models.to_section import (
     TopicConfig,
 )
 from kpops.components.streams_bootstrap.app_type import AppType
-from kpops.components.streams_bootstrap.producer.model import ProducerValues
+from kpops.components.streams_bootstrap.producer.model import ProducerAppValues
 from kpops.utils.docstring import describe_attr
 
 
@@ -25,7 +25,7 @@ class ProducerApp(KafkaApp):
     :param from_: Producer doesn't support FromSection, defaults to None
     """
 
-    app: ProducerValues = Field(
+    app: ProducerAppValues = Field(
         default=...,
         description=describe_attr("app", __doc__),
     )

--- a/kpops/components/streams_bootstrap/streams/model.py
+++ b/kpops/components/streams_bootstrap/streams/model.py
@@ -5,7 +5,7 @@ from pydantic import ConfigDict, Field, SerializationInfo, model_serializer
 
 from kpops.components.base_components.base_defaults_component import deduplicate
 from kpops.components.base_components.kafka_app import (
-    KafkaAppConfig,
+    KafkaAppValues,
     KafkaStreamsConfig,
 )
 from kpops.utils.docstring import describe_attr
@@ -166,7 +166,7 @@ class StreamsAppAutoScaling(CamelCaseConfigModel, DescConfigModel):
     model_config = ConfigDict(extra="allow")
 
 
-class StreamsAppConfig(KafkaAppConfig):
+class StreamsAppValues(KafkaAppValues):
     """StreamsBoostrap app configurations.
 
     The attributes correspond to keys and values that are used as values for the streams bootstrap helm chart.

--- a/kpops/components/streams_bootstrap/streams/streams_app.py
+++ b/kpops/components/streams_bootstrap/streams/streams_app.py
@@ -3,7 +3,7 @@ from typing_extensions import override
 
 from kpops.components.base_components.kafka_app import KafkaApp
 from kpops.components.streams_bootstrap.app_type import AppType
-from kpops.components.streams_bootstrap.streams.model import StreamsAppConfig
+from kpops.components.streams_bootstrap.streams.model import StreamsAppValues
 from kpops.utils.docstring import describe_attr
 
 
@@ -13,7 +13,7 @@ class StreamsApp(KafkaApp):
     :param app: Application-specific settings
     """
 
-    app: StreamsAppConfig = Field(
+    app: StreamsAppValues = Field(
         default=...,
         description=describe_attr("app", __doc__),
     )

--- a/kpops/pipeline.py
+++ b/kpops/pipeline.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 from collections import Counter
-from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -53,7 +52,6 @@ class Pipeline(RootModel):
         raise ValueError(msg)
 
     def add(self, component: PipelineComponent) -> None:
-        self._populate_component_name(component)
         self.root.append(component)
 
     def __bool__(self) -> bool:
@@ -77,14 +75,6 @@ class Pipeline(RootModel):
         if duplicates:
             msg = f"step names should be unique. duplicate step names: {', '.join(duplicates)}"
             raise ValidationError(msg)
-
-    @staticmethod
-    def _populate_component_name(component: PipelineComponent) -> None:  # TODO: remove
-        with suppress(
-            AttributeError  # Some components like Kafka Connect do not have a name_override attribute
-        ):
-            if (app := getattr(component, "app")) and app.name_override is None:
-                app.name_override = component.full_name
 
 
 def create_env_components_index(

--- a/tests/components/test_helm_app.py
+++ b/tests/components/test_helm_app.py
@@ -12,16 +12,11 @@ from kpops.component_handlers.helm_wrapper.model import (
     HelmUpgradeInstallFlags,
     RepoAuthFlags,
 )
-from kpops.components.base_components.helm_app import HelmApp
-from kpops.components.base_components.kubernetes_app import KubernetesAppConfig
+from kpops.components.base_components.helm_app import HelmApp, HelmAppConfig
 from kpops.config import KpopsConfig
 from kpops.utils.colorify import magentaify
 
 DEFAULTS_PATH = Path(__file__).parent / "resources"
-
-
-class HelmTestValue(KubernetesAppConfig):
-    name_override: str
 
 
 class TestHelmApp:
@@ -51,8 +46,8 @@ class TestHelmApp:
         return mocker.patch("kpops.components.base_components.helm_app.log.info")
 
     @pytest.fixture()
-    def app_value(self) -> HelmTestValue:
-        return HelmTestValue(name_override="test-value")
+    def app_value(self) -> HelmAppConfig:
+        return HelmAppConfig(**{"foo": "test-value"})
 
     @pytest.fixture()
     def repo_config(self) -> HelmRepoConfig:
@@ -63,7 +58,7 @@ class TestHelmApp:
         self,
         config: KpopsConfig,
         handlers: ComponentHandlers,
-        app_value: HelmTestValue,
+        app_value: HelmAppConfig,
         repo_config: HelmRepoConfig,
     ) -> HelmApp:
         return HelmApp(
@@ -97,7 +92,10 @@ class TestHelmApp:
             "test/test-chart",
             False,
             "test-namespace",
-            {"nameOverride": "test-value"},
+            {
+                "nameOverride": "${pipeline_name}-test-helm-app",
+                "foo": "test-value",
+            },
             HelmUpgradeInstallFlags(),
         )
 
@@ -107,7 +105,7 @@ class TestHelmApp:
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
         mocker: MockerFixture,
-        app_value: HelmTestValue,
+        app_value: HelmAppConfig,
     ):
         repo_config = HelmRepoConfig(
             repository_name="test-repo", url="https://test.com/charts/"
@@ -142,7 +140,10 @@ class TestHelmApp:
                 "test/test-chart",
                 False,
                 "test-namespace",
-                {"nameOverride": "test-value"},
+                {
+                    "nameOverride": "${pipeline_name}-test-helm-app",
+                    "foo": "test-value",
+                },
                 HelmUpgradeInstallFlags(version="3.4.5"),
             ),
         ]
@@ -152,7 +153,7 @@ class TestHelmApp:
         config: KpopsConfig,
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
-        app_value: HelmTestValue,
+        app_value: HelmAppConfig,
     ):
         class AppWithLocalChart(HelmApp):
             repo_config: None = None
@@ -179,7 +180,10 @@ class TestHelmApp:
             "path/to/helm/charts/",
             False,
             "test-namespace",
-            {"nameOverride": "test-value"},
+            {
+                "nameOverride": "${pipeline_name}-test-app-with-local-chart",
+                "foo": "test-value",
+            },
             HelmUpgradeInstallFlags(),
         )
 

--- a/tests/components/test_helm_app.py
+++ b/tests/components/test_helm_app.py
@@ -46,7 +46,7 @@ class TestHelmApp:
         return mocker.patch("kpops.components.base_components.helm_app.log.info")
 
     @pytest.fixture()
-    def app_value(self) -> HelmAppValues:
+    def app_values(self) -> HelmAppValues:
         return HelmAppValues(**{"foo": "test-value"})
 
     @pytest.fixture()
@@ -58,14 +58,14 @@ class TestHelmApp:
         self,
         config: KpopsConfig,
         handlers: ComponentHandlers,
-        app_value: HelmAppValues,
+        app_values: HelmAppValues,
         repo_config: HelmRepoConfig,
     ) -> HelmApp:
         return HelmApp(
             name="test-helm-app",
             config=config,
             handlers=handlers,
-            app=app_value,
+            app=app_values,
             namespace="test-namespace",
             repo_config=repo_config,
         )
@@ -105,7 +105,7 @@ class TestHelmApp:
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
         mocker: MockerFixture,
-        app_value: HelmAppValues,
+        app_values: HelmAppValues,
     ):
         repo_config = HelmRepoConfig(
             repository_name="test-repo", url="https://test.com/charts/"
@@ -114,7 +114,7 @@ class TestHelmApp:
             name="test-helm-app",
             config=config,
             handlers=handlers,
-            app=app_value,
+            app=app_values,
             namespace="test-namespace",
             repo_config=repo_config,
             version="3.4.5",
@@ -153,7 +153,7 @@ class TestHelmApp:
         config: KpopsConfig,
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
-        app_value: HelmAppValues,
+        app_values: HelmAppValues,
     ):
         class AppWithLocalChart(HelmApp):
             repo_config: None = None
@@ -167,7 +167,7 @@ class TestHelmApp:
             name="test-app-with-local-chart",
             config=config,
             handlers=handlers,
-            app=app_value,
+            app=app_values,
             namespace="test-namespace",
         )
 

--- a/tests/components/test_helm_app.py
+++ b/tests/components/test_helm_app.py
@@ -12,7 +12,7 @@ from kpops.component_handlers.helm_wrapper.model import (
     HelmUpgradeInstallFlags,
     RepoAuthFlags,
 )
-from kpops.components.base_components.helm_app import HelmApp, HelmAppConfig
+from kpops.components.base_components.helm_app import HelmApp, HelmAppValues
 from kpops.config import KpopsConfig
 from kpops.utils.colorify import magentaify
 
@@ -46,8 +46,8 @@ class TestHelmApp:
         return mocker.patch("kpops.components.base_components.helm_app.log.info")
 
     @pytest.fixture()
-    def app_value(self) -> HelmAppConfig:
-        return HelmAppConfig(**{"foo": "test-value"})
+    def app_value(self) -> HelmAppValues:
+        return HelmAppValues(**{"foo": "test-value"})
 
     @pytest.fixture()
     def repo_config(self) -> HelmRepoConfig:
@@ -58,7 +58,7 @@ class TestHelmApp:
         self,
         config: KpopsConfig,
         handlers: ComponentHandlers,
-        app_value: HelmAppConfig,
+        app_value: HelmAppValues,
         repo_config: HelmRepoConfig,
     ) -> HelmApp:
         return HelmApp(
@@ -105,7 +105,7 @@ class TestHelmApp:
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
         mocker: MockerFixture,
-        app_value: HelmAppConfig,
+        app_value: HelmAppValues,
     ):
         repo_config = HelmRepoConfig(
             repository_name="test-repo", url="https://test.com/charts/"
@@ -153,7 +153,7 @@ class TestHelmApp:
         config: KpopsConfig,
         handlers: ComponentHandlers,
         helm_mock: MagicMock,
-        app_value: HelmAppConfig,
+        app_value: HelmAppValues,
     ):
         class AppWithLocalChart(HelmApp):
             repo_config: None = None

--- a/tests/components/test_kafka_app.py
+++ b/tests/components/test_kafka_app.py
@@ -97,6 +97,7 @@ class TestKafkaApp:
             True,
             "test-namespace",
             {
+                "nameOverride": "${pipeline_name}-example-name",
                 "streams": {"brokers": "fake-broker:9092", "outputTopic": "test"},
             },
             HelmUpgradeInstallFlags(version="1.2.3"),

--- a/tests/components/test_kubernetes_app.py
+++ b/tests/components/test_kubernetes_app.py
@@ -36,7 +36,7 @@ class TestKubernetesApp:
         return mocker.patch("kpops.components.base_components.kubernetes_app.log.info")
 
     @pytest.fixture()
-    def app_value(self) -> KubernetesTestValue:
+    def app_values(self) -> KubernetesTestValue:
         return KubernetesTestValue(foo="foo")
 
     @pytest.fixture()
@@ -44,13 +44,13 @@ class TestKubernetesApp:
         self,
         config: KpopsConfig,
         handlers: ComponentHandlers,
-        app_value: KubernetesTestValue,
+        app_values: KubernetesTestValue,
     ) -> KubernetesApp:
         return KubernetesApp(
             name="test-kubernetes-app",
             config=config,
             handlers=handlers,
-            app=app_value,
+            app=app_values,
             namespace="test-namespace",
         )
 
@@ -58,7 +58,7 @@ class TestKubernetesApp:
         self,
         config: KpopsConfig,
         handlers: ComponentHandlers,
-        app_value: KubernetesTestValue,
+        app_values: KubernetesTestValue,
     ):
         with pytest.raises(
             ValueError, match=r"The component name .* is invalid for Kubernetes."
@@ -67,7 +67,7 @@ class TestKubernetesApp:
                 name="Not-Compatible*",
                 config=config,
                 handlers=handlers,
-                app=app_value,
+                app=app_values,
                 namespace="test-namespace",
             )
 
@@ -78,7 +78,7 @@ class TestKubernetesApp:
                 name="snake_case*",
                 config=config,
                 handlers=handlers,
-                app=app_value,
+                app=app_values,
                 namespace="test-namespace",
             )
 
@@ -86,6 +86,6 @@ class TestKubernetesApp:
             name="valid-name",
             config=config,
             handlers=handlers,
-            app=app_value,
+            app=app_values,
             namespace="test-namespace",
         )

--- a/tests/components/test_kubernetes_app.py
+++ b/tests/components/test_kubernetes_app.py
@@ -7,14 +7,14 @@ from pytest_mock import MockerFixture
 from kpops.component_handlers import ComponentHandlers
 from kpops.components.base_components.kubernetes_app import (
     KubernetesApp,
-    KubernetesAppConfig,
+    KubernetesAppValues,
 )
 from kpops.config import KpopsConfig
 
 DEFAULTS_PATH = Path(__file__).parent / "resources"
 
 
-class KubernetesTestValue(KubernetesAppConfig):
+class KubernetesTestValue(KubernetesAppValues):
     foo: str
 
 

--- a/tests/components/test_producer_app.py
+++ b/tests/components/test_producer_app.py
@@ -120,6 +120,7 @@ class TestProducerApp:
                 False,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.PRODUCER_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "outputTopic": "${output_topic_name}",
@@ -184,6 +185,7 @@ class TestProducerApp:
                 True,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.PRODUCER_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "outputTopic": "${output_topic_name}",
@@ -229,6 +231,7 @@ class TestProducerApp:
                 False,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.PRODUCER_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "outputTopic": "${output_topic_name}",

--- a/tests/components/test_streams_app.py
+++ b/tests/components/test_streams_app.py
@@ -323,6 +323,7 @@ class TestStreamsApp:
                 dry_run,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.STREAMS_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "extraOutputTopics": {
@@ -331,7 +332,7 @@ class TestStreamsApp:
                         },
                         "outputTopic": "${output_topic_name}",
                         "errorTopic": "${error_topic_name}",
-                    }
+                    },
                 },
                 HelmUpgradeInstallFlags(
                     create_namespace=False,
@@ -384,6 +385,7 @@ class TestStreamsApp:
                 dry_run,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.STREAMS_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "outputTopic": "${output_topic_name}",
@@ -428,6 +430,7 @@ class TestStreamsApp:
                 dry_run,
                 "test-namespace",
                 {
+                    "nameOverride": "${pipeline_name}-" + self.STREAMS_APP_NAME,
                     "streams": {
                         "brokers": "fake-broker:9092",
                         "outputTopic": "${output_topic_name}",

--- a/tests/pipeline/snapshots/snap_test_example.py
+++ b/tests/pipeline/snapshots/snap_test_example.py
@@ -13,7 +13,6 @@ snapshots['TestExample.test_atm_fraud atm-fraud-pipeline'] = [
             'debug': True,
             'image': '${DOCKER_REGISTRY}/atm-demo-accountproducer',
             'imageTag': '1.0.0',
-            'nameOverride': 'account-producer',
             'prometheus': {
                 'jmx': {
                     'enabled': False
@@ -64,7 +63,6 @@ snapshots['TestExample.test_atm_fraud atm-fraud-pipeline'] = [
             'debug': True,
             'image': '${DOCKER_REGISTRY}/atm-demo-transactionavroproducer',
             'imageTag': '1.0.0',
-            'nameOverride': 'transaction-avro-producer',
             'prometheus': {
                 'jmx': {
                     'enabled': False
@@ -120,7 +118,6 @@ snapshots['TestExample.test_atm_fraud atm-fraud-pipeline'] = [
             'labels': {
                 'pipeline': 'bakdata-atm-fraud-detection'
             },
-            'nameOverride': 'transaction-joiner',
             'prometheus': {
                 'jmx': {
                     'enabled': False
@@ -182,7 +179,6 @@ snapshots['TestExample.test_atm_fraud atm-fraud-pipeline'] = [
             'labels': {
                 'pipeline': 'bakdata-atm-fraud-detection'
             },
-            'nameOverride': 'fraud-detector',
             'prometheus': {
                 'jmx': {
                     'enabled': False
@@ -244,7 +240,6 @@ snapshots['TestExample.test_atm_fraud atm-fraud-pipeline'] = [
             'labels': {
                 'pipeline': 'bakdata-atm-fraud-detection'
             },
-            'nameOverride': 'account-linker',
             'prometheus': {
                 'jmx': {
                     'enabled': False

--- a/tests/pipeline/snapshots/snap_test_pipeline.py
+++ b/tests/pipeline/snapshots/snap_test_pipeline.py
@@ -10,7 +10,6 @@ snapshots = Snapshot()
 snapshots['TestPipeline.test_default_config test-pipeline'] = [
     {
         'app': {
-            'nameOverride': 'resources-custom-config-app1',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -58,7 +57,6 @@ snapshots['TestPipeline.test_default_config test-pipeline'] = [
             'labels': {
                 'pipeline': 'resources-custom-config'
             },
-            'nameOverride': 'resources-custom-config-app2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'errorTopic': 'resources-custom-config-app2-error',
@@ -110,7 +108,6 @@ snapshots['TestPipeline.test_inflate_pipeline test-pipeline'] = [
             },
             'image': 'example-registry/fake-image',
             'imageTag': '0.0.1',
-            'nameOverride': 'resources-pipeline-with-inflate-scheduled-producer',
             'schedule': '30 3/8 * * *',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
@@ -165,7 +162,6 @@ snapshots['TestPipeline.test_inflate_pipeline test-pipeline'] = [
             'commandLine': {
                 'CONVERT_XML': True
             },
-            'nameOverride': 'resources-pipeline-with-inflate-converter',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -242,7 +238,6 @@ snapshots['TestPipeline.test_inflate_pipeline test-pipeline'] = [
             },
             'image': 'fake-registry/filter',
             'imageTag': '2.4.1',
-            'nameOverride': 'resources-pipeline-with-inflate-should-inflate',
             'replicaCount': 4,
             'resources': {
                 'requests': {
@@ -345,7 +340,6 @@ snapshots['TestPipeline.test_inflate_pipeline test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-pipeline-with-inflate-should-inflate-inflated-streams-app',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -397,7 +391,6 @@ snapshots['TestPipeline.test_kafka_connect_sink_weave_from_topics test-pipeline'
     {
         'app': {
             'image': 'fake-image',
-            'nameOverride': 'resources-kafka-connect-sink-streams-app',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -492,7 +485,6 @@ snapshots['TestPipeline.test_load_pipeline test-pipeline'] = [
             },
             'image': 'example-registry/fake-image',
             'imageTag': '0.0.1',
-            'nameOverride': 'resources-first-pipeline-scheduled-producer',
             'schedule': '30 3/8 * * *',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
@@ -547,7 +539,6 @@ snapshots['TestPipeline.test_load_pipeline test-pipeline'] = [
             'commandLine': {
                 'CONVERT_XML': True
             },
-            'nameOverride': 'resources-first-pipeline-converter',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -624,7 +615,6 @@ snapshots['TestPipeline.test_load_pipeline test-pipeline'] = [
             },
             'image': 'fake-registry/filter',
             'imageTag': '2.4.1',
-            'nameOverride': 'resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name',
             'replicaCount': 4,
             'resources': {
                 'requests': {
@@ -683,7 +673,6 @@ snapshots['TestPipeline.test_load_pipeline test-pipeline'] = [
 snapshots['TestPipeline.test_model_serialization test-pipeline'] = [
     {
         'app': {
-            'nameOverride': 'resources-pipeline-with-paths-account-producer',
             'streams': {
                 'brokers': 'test',
                 'extraOutputTopics': {
@@ -716,7 +705,6 @@ snapshots['TestPipeline.test_no_input_topic test-pipeline'] = [
             'commandLine': {
                 'CONVERT_XML': True
             },
-            'nameOverride': 'resources-no-input-topic-pipeline-app1',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -779,7 +767,6 @@ snapshots['TestPipeline.test_no_input_topic test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-no-input-topic-pipeline-app2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -839,7 +826,6 @@ snapshots['TestPipeline.test_no_user_defined_components test-pipeline'] = [
     {
         'app': {
             'image': 'fake-image',
-            'nameOverride': 'resources-no-user-defined-components-streams-app',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -904,7 +890,6 @@ snapshots['TestPipeline.test_pipelines_with_env_values test-pipeline'] = [
             },
             'image': 'example-registry/fake-image',
             'imageTag': '0.0.1',
-            'nameOverride': 'resources-pipeline-with-envs-input-producer',
             'schedule': '20 3/8 * * *',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
@@ -959,7 +944,6 @@ snapshots['TestPipeline.test_pipelines_with_env_values test-pipeline'] = [
             'commandLine': {
                 'CONVERT_XML': True
             },
-            'nameOverride': 'resources-pipeline-with-envs-converter',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -1036,7 +1020,6 @@ snapshots['TestPipeline.test_pipelines_with_env_values test-pipeline'] = [
             },
             'image': 'fake-registry/filter',
             'imageTag': '2.4.1',
-            'nameOverride': 'resources-pipeline-with-envs-filter',
             'replicaCount': 4,
             'resources': {
                 'requests': {
@@ -1098,7 +1081,6 @@ snapshots['TestPipeline.test_prefix_pipeline_component test-pipeline'] = [
             'debug': True,
             'image': '${DOCKER_REGISTRY}/atm-demo-accountproducer',
             'imageTag': '1.0.0',
-            'nameOverride': 'from-pipeline-component-account-producer',
             'prometheus': {
                 'jmx': {
                     'enabled': False
@@ -1132,7 +1114,6 @@ snapshots['TestPipeline.test_prefix_pipeline_component test-pipeline'] = [
 snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-producer1',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'extraOutputTopics': {
@@ -1167,7 +1148,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'producer2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'extraOutputTopics': {
@@ -1217,7 +1197,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
             },
             'image': 'fake-registry/filter',
             'imageTag': '2.4.1',
-            'nameOverride': 'resources-read-from-component-inflate-step',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1314,7 +1293,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-inflate-step-inflated-streams-app',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1377,7 +1355,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
             },
             'image': 'fake-registry/filter',
             'imageTag': '2.4.1',
-            'nameOverride': 'inflate-step-without-prefix',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1474,7 +1451,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-inflate-step-without-prefix-inflated-streams-app',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1522,7 +1498,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-consumer1',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1579,7 +1554,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-consumer2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1634,7 +1608,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-consumer3',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1689,7 +1662,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-consumer4',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1740,7 +1712,6 @@ snapshots['TestPipeline.test_read_from_component test-pipeline'] = [
     },
     {
         'app': {
-            'nameOverride': 'resources-read-from-component-consumer5',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {
@@ -1804,7 +1775,6 @@ snapshots['TestPipeline.test_substitute_in_component test-pipeline'] = [
                 'app_schedule': '30 3/8 * * *',
                 'app_type': 'scheduled-producer'
             },
-            'nameOverride': 'resources-component-type-substitution-scheduled-producer',
             'schedule': '30 3/8 * * *',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
@@ -1859,7 +1829,6 @@ snapshots['TestPipeline.test_substitute_in_component test-pipeline'] = [
             'commandLine': {
                 'CONVERT_XML': True
             },
-            'nameOverride': 'resources-component-type-substitution-converter',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -1943,7 +1912,6 @@ snapshots['TestPipeline.test_substitute_in_component test-pipeline'] = [
                 'filter': 'filter-app-filter',
                 'test_placeholder_in_placeholder': 'filter-app-filter'
             },
-            'nameOverride': 'resources-component-type-substitution-filter-app',
             'replicaCount': 4,
             'resources': {
                 'requests': {
@@ -2002,7 +1970,6 @@ snapshots['TestPipeline.test_substitute_in_component test-pipeline'] = [
 snapshots['TestPipeline.test_with_custom_config_with_absolute_defaults_path test-pipeline'] = [
     {
         'app': {
-            'nameOverride': 'resources-custom-config-app1',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -2050,7 +2017,6 @@ snapshots['TestPipeline.test_with_custom_config_with_absolute_defaults_path test
             'labels': {
                 'pipeline': 'resources-custom-config'
             },
-            'nameOverride': 'resources-custom-config-app2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'errorTopic': 'app2-dead-letter-topic',
@@ -2097,7 +2063,6 @@ snapshots['TestPipeline.test_with_custom_config_with_absolute_defaults_path test
 snapshots['TestPipeline.test_with_custom_config_with_relative_defaults_path test-pipeline'] = [
     {
         'app': {
-            'nameOverride': 'resources-custom-config-app1',
             'resources': {
                 'limits': {
                     'memory': '2G'
@@ -2145,7 +2110,6 @@ snapshots['TestPipeline.test_with_custom_config_with_relative_defaults_path test
             'labels': {
                 'pipeline': 'resources-custom-config'
             },
-            'nameOverride': 'resources-custom-config-app2',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'errorTopic': 'app2-dead-letter-topic',
@@ -2193,7 +2157,6 @@ snapshots['TestPipeline.test_with_env_defaults test-pipeline'] = [
     {
         'app': {
             'image': 'fake-image',
-            'nameOverride': 'resources-kafka-connect-sink-streams-app-development',
             'streams': {
                 'brokers': 'http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092',
                 'config': {


### PR DESCRIPTION
Fixes #327 

Remove previous workaround for setting Helm app `nameOverride` in favor of a more robust implementation in `HelmApp`
