### PR TITLE
Fix broken doc link

### DIFF
--- a/docs/docs/resources/architecture/components-hierarchy.md
+++ b/docs/docs/resources/architecture/components-hierarchy.md
@@ -12,15 +12,15 @@ flowchart BT
     KafkaSourceConnector --> KafkaConnector
     KafkaSinkConnector --> KafkaConnector
 
-    click KubernetesApp "/kpops/user/core-concepts/components/kubernetes-app"
-    click HelmApp "/kpops/user/core-concepts/components/helm-app"
-    click KafkaApp "/kpops/user/core-concepts/components/kafka-app"
-    click StreamsBootstrap "/kpops/user/core-concepts/components/streams-bootstrap"
-    click StreamsApp "/kpops/user/core-concepts/components/streams-app"
-    click ProducerApp "/kpops/user/core-concepts/components/producer-app"
-    click KafkaConnector "/kpops/user/core-concepts/components/kafka-connector"
-    click KafkaSourceConnector "/kpops/user/core-concepts/components/kafka-source-connector"
-    click KafkaSinkConnector "/kpops/user/core-concepts/components/kafka-sink-connector"
+    click KubernetesApp "./../kubernetes-app"
+    click HelmApp "./../helm-app"
+    click KafkaApp "./../kafka-app"
+    click StreamsBootstrap "./../streams-bootstrap"
+    click StreamsApp "./../streams-app"
+    click ProducerApp "./../producer-app"
+    click KafkaConnector "./../kafka-connector"
+    click KafkaSourceConnector "./../kafka-source-connector"
+    click KafkaSinkConnector "./../kafka-sink-connector"
 ```
 
 <p style="text-align: center;"><i>KPOps component hierarchy</i></p>

--- a/docs/docs/resources/examples/pipeline.md
+++ b/docs/docs/resources/examples/pipeline.md
@@ -1,6 +1,6 @@
 # Example `pipeline.yaml` files
 
-## [ATM Fraud Pipeline](https://github.com/bakdata/kpops/tree/main/examples/bakdata/atm-fraud-detection){target=_blank}
+## [ATM Fraud Pipeline](https://github.com/bakdata/kpops-examples/tree/main/atm-fraud){target=_blank}
 
 <!-- dprint-ignore-start -->
 

--- a/docs/docs/resources/examples/pipeline.md
+++ b/docs/docs/resources/examples/pipeline.md
@@ -7,7 +7,7 @@
 ??? example "pipeline.yaml"
     ```yaml
      --8<--
-     https://raw.githubusercontent.com/bakdata/kpops-examples/main/word-count/pipeline.yaml
+     https://raw.githubusercontent.com/bakdata/kpops-examples/main/atm-fraud/pipeline.yaml
      --8<--
     ```
 

--- a/docs/docs/resources/examples/pipeline.md
+++ b/docs/docs/resources/examples/pipeline.md
@@ -7,7 +7,7 @@
 ??? example "pipeline.yaml"
     ```yaml
      --8<--
-     https://raw.githubusercontent.com/bakdata/kpops/main/examples/bakdata/atm-fraud-detection/pipeline.yaml
+     https://raw.githubusercontent.com/bakdata/kpops-examples/main/word-count/pipeline.yaml
      --8<--
     ```
 


### PR DESCRIPTION
```bash
just serve-docs
...
INFO    -  Building documentation...
INFO    -  [macros] - Macros arguments: {'module_name': 'main', 'modules': [], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '',
           'j2_variable_start_string': '', 'j2_variable_end_string': '', 'on_undefined': 'keep', 'on_error_fail': False, 'verbose': False}
INFO    -  [macros] - Extra variables (config file): ['version']
INFO    -  [macros] - Extra filters (module): ['pretty']
INFO    -  Cleaning site directory
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - resources/architecture/components-hierarchy.md
             - resources/examples/defaults.md
             - resources/examples/pipeline.md
             - resources/pipeline-components/pipeline.md
             - resources/pipeline-defaults/defaults.md
             - resources/variables/cli_env_vars.md
             - resources/variables/config_env_vars.md
ERROR   -  Error reading page 'resources/examples/pipeline.md': HTTP Error 404: Not Found

HTTPError: HTTP Error 404: Not Found

```