### PR TITLE
Add custom PascalCase to snake_case alias generator

### DIFF
--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import humps
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.alias_generators import to_snake
 from pydantic.fields import FieldInfo
 from pydantic_settings import PydanticBaseSettingsSource
 from typing_extensions import TypeVar, override
@@ -22,6 +21,11 @@ def to_camel(s: str) -> str:
 def to_dash(s: str) -> str:
     """Convert PascalCase to dash-case."""
     return humps.depascalize(s).lower().replace("_", "-")
+
+
+def to_snake(s: str) -> str:
+    """Convert PascalCase to snake_case."""
+    return humps.depascalize(s).lower()
 
 
 def to_dot(s: str) -> str:

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kpops.utils.pydantic import to_dash
+from kpops.utils.pydantic import to_dash, to_snake
 
 
 @pytest.mark.parametrize(
@@ -12,7 +12,24 @@ from kpops.utils.pydantic import to_dash
         ("ExampleACRONYMComponent", "example-acronym-component"),
         ("ComponentWithACRONYM", "component-with-acronym"),
         ("ComponentWithDIGIT00", "component-with-digit00"),
+        ("S3Test", "s3-test"),
     ],
 )
 def test_to_dash(input: str, expected: str):
     assert to_dash(input) == expected
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("BaseDefaultsComponent", "base_defaults_component"),
+        ("ACRONYM", "acronym"),
+        ("ACRONYMComponent", "acronym_component"),
+        ("ExampleACRONYMComponent", "example_acronym_component"),
+        ("ComponentWithACRONYM", "component_with_acronym"),
+        ("ComponentWithDIGIT00", "component_with_digit00"),
+        ("S3Test", "s3_test"),
+    ],
+)
+def test_to_snake(input: str, expected: str):
+    assert to_snake(input) == expected

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -28,7 +28,7 @@ def test_to_dash(input: str, expected: str):
         ("ExampleACRONYMComponent", "example_acronym_component"),
         ("ComponentWithACRONYM", "component_with_acronym"),
         ("ComponentWithDIGIT00", "component_with_digit00"),
-        ("S3Test", "s3_test"),
+        ("S3Test", "s3_test"),  # NOTE: this one fails with Pydantic's to_snake util
     ],
 )
 def test_to_snake(input: str, expected: str):


### PR DESCRIPTION
better than Pydantic's builtin alias generator (see tests)
