### PR TITLE
Set Pyright to warn on unknown types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,14 @@ mike = "^1.1.2"
 [tool.poetry_bumpversion.file."kpops/__init__.py"]
 
 [tool.pyright]
+reportUnknownParameterType = "warning"
+reportUnknownArgumentType = "warning"
+reportUnknownLambdaType = "warning"
+reportUnknownVariableType = "warning"
+reportUnknownMemberType = "warning"
+
 reportIncompatibleVariableOverride = false
 reportIncompatibleMethodOverride = false
-
 # FIXME: causes issues on Python 3.10
 # reportIncompatibleVariableOverride = "warning"
 # reportIncompatibleMethodOverride = "warning"


### PR DESCRIPTION
Closes #367

"warning" diagnostics don't cause the pre-commit hook to fail, but you'll get those highlighted in the code when using Pyright/Pylance LSP
