### PR TITLE
Convert all values of Kafka connector and topic config to string

### DIFF
--- a/docs/docs/schema/defaults.json
+++ b/docs/docs/schema/defaults.json
@@ -459,7 +459,22 @@
         "KafkaConnectorConfig": {
             "additionalProperties": true,
             "additional_properties": {
-                "type": "string"
+                "type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
             },
             "description": "Settings specific to Kafka Connectors.",
             "properties": {

--- a/docs/docs/schema/pipeline.json
+++ b/docs/docs/schema/pipeline.json
@@ -285,7 +285,22 @@
         "KafkaConnectorConfig": {
             "additionalProperties": true,
             "additional_properties": {
-                "type": "string"
+                "type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
             },
             "description": "Settings specific to Kafka Connectors.",
             "properties": {

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from typing import Any
 
@@ -85,9 +86,9 @@ class KafkaConnectorConfig(DescConfigModel):
 
     @staticmethod
     def serialize_to_str(value: Any) -> str:
-        if isinstance(value, bool):
-            return "true" if value else "false"
-        return str(value)
+        if isinstance(value, str):
+            return value
+        return json.dumps(value)
 
     # TODO(Ivan Yordanov): Currently hacky and potentially unsafe. Find cleaner solution
     @model_serializer(mode="wrap", when_used="always")

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -80,9 +80,9 @@ class KafkaConnectorConfig(DescConfigModel):
         self,
         default_serialize_handler: pydantic.SerializerFunctionWrapHandler,
         info: pydantic.SerializationInfo,
-    ) -> dict[str, Any]:
+    ) -> dict[str, str]:
         result = exclude_by_value(default_serialize_handler(self), None)
-        return {by_alias(self, name): value for name, value in result.items()}
+        return {by_alias(self, name): str(value) for name, value in result.items()}
 
 
 class ConnectorTask(BaseModel):

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -74,6 +74,14 @@ class KafkaConnectorConfig(DescConfigModel):
             return None
         return ",".join(topic.name for topic in topics)
 
+    @staticmethod
+    def serialize_to_str(value: Any) -> str:
+        if value is True:
+            return "true"
+        if value is False:
+            return "false"
+        return str(value)
+
     # TODO(Ivan Yordanov): Currently hacky and potentially unsafe. Find cleaner solution
     @model_serializer(mode="wrap", when_used="always")
     def serialize_model(
@@ -82,7 +90,10 @@ class KafkaConnectorConfig(DescConfigModel):
         info: pydantic.SerializationInfo,
     ) -> dict[str, str]:
         result = exclude_by_value(default_serialize_handler(self), None)
-        return {by_alias(self, name): str(value) for name, value in result.items()}
+        return {
+            by_alias(self, name): self.serialize_to_str(value)
+            for name, value in result.items()
+        }
 
 
 class ConnectorTask(BaseModel):

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 from typing import Any
 
@@ -18,6 +17,7 @@ from kpops.utils.pydantic import (
     by_alias,
     exclude_by_value,
     to_dot,
+    to_str,
 )
 
 
@@ -84,12 +84,6 @@ class KafkaConnectorConfig(DescConfigModel):
             return None
         return ",".join(topic.name for topic in topics)
 
-    @staticmethod
-    def serialize_to_str(value: Any) -> str:
-        if isinstance(value, str):
-            return value
-        return json.dumps(value)
-
     # TODO(Ivan Yordanov): Currently hacky and potentially unsafe. Find cleaner solution
     @model_serializer(mode="wrap", when_used="always")
     def serialize_model(
@@ -98,10 +92,7 @@ class KafkaConnectorConfig(DescConfigModel):
         info: pydantic.SerializationInfo,
     ) -> dict[str, str]:
         result = exclude_by_value(default_serialize_handler(self), None)
-        return {
-            by_alias(self, name): self.serialize_to_str(value)
-            for name, value in result.items()
-        }
+        return {by_alias(self, name): to_str(value) for name, value in result.items()}
 
 
 class ConnectorTask(BaseModel):

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -85,10 +85,8 @@ class KafkaConnectorConfig(DescConfigModel):
 
     @staticmethod
     def serialize_to_str(value: Any) -> str:
-        if value is True:
-            return "true"
-        if value is False:
-            return "false"
+        if isinstance(value, bool):
+            return "true" if value else "false"
         return str(value)
 
     # TODO(Ivan Yordanov): Currently hacky and potentially unsafe. Find cleaner solution

--- a/kpops/component_handlers/kafka_connect/model.py
+++ b/kpops/component_handlers/kafka_connect/model.py
@@ -40,7 +40,16 @@ class KafkaConnectorConfig(DescConfigModel):
         super(KafkaConnectorConfig, KafkaConnectorConfig).json_schema_extra(
             schema, model
         )
-        schema["additional_properties"] = {"type": "string"}
+        schema["additional_properties"] = {
+            "type": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "boolean"},
+                    {"type": "integer"},
+                    {"type": "number"},
+                ],
+            }
+        }
 
     model_config = ConfigDict(
         extra="allow",

--- a/kpops/components/common/topic.py
+++ b/kpops/components/common/topic.py
@@ -8,7 +8,7 @@ import pydantic
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from kpops.utils.docstring import describe_attr
-from kpops.utils.pydantic import DescConfigModel
+from kpops.utils.pydantic import DescConfigModel, to_str
 
 
 class OutputTopicTypes(str, Enum):
@@ -75,6 +75,10 @@ class TopicConfig(DescConfigModel):
             msg = "Define `label` only if `type` is undefined"
             raise ValueError(msg)
         return self
+
+    @pydantic.field_serializer("configs")
+    def serialize_configs(self, configs: dict[str, str | int]) -> dict[str, str]:
+        return {key: to_str(value) for key, value in configs.items()}
 
 
 class KafkaTopic(BaseModel):

--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,12 @@ def by_alias(model: BaseModel, field_name: str) -> str:
     :param model: Model that owns the field
     """
     return model.model_fields.get(field_name, Field()).alias or field_name
+
+
+def to_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
 
 
 _V = TypeVar("_V")

--- a/tests/component_handlers/kafka_connect/test_connect_wrapper.py
+++ b/tests/component_handlers/kafka_connect/test_connect_wrapper.py
@@ -40,6 +40,30 @@ class TestConnectorApiWrapper:
             }
         )
 
+    def test_convert_config_values_to_str(self):
+        # all values should be converted to strings
+        assert KafkaConnectorConfig.model_validate(
+            {
+                "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+                "name": "test-connector",
+                "batch.size": 50,
+                "max.buffered.records": 500,
+                "connection.password": "fake-password",
+                "store.kafka.keys": True,
+                "retention.ms": -1,
+                "topic.tracking.allow.reset": False,
+            }
+        ).model_dump() == {
+            "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+            "name": "test-connector",
+            "batch.size": "50",
+            "max.buffered.records": "500",
+            "connection.password": "fake-password",
+            "store.kafka.keys": "true",
+            "retention.ms": "-1",
+            "topic.tracking.allow.reset": "false",
+        }
+
     @pytest.mark.asyncio()
     @patch("httpx.AsyncClient.post")
     async def test_should_create_post_requests_for_given_connector_configuration(

--- a/tests/component_handlers/kafka_connect/test_connect_wrapper.py
+++ b/tests/component_handlers/kafka_connect/test_connect_wrapper.py
@@ -50,7 +50,7 @@ class TestConnectorApiWrapper:
                 "max.buffered.records": 500,
                 "connection.password": "fake-password",
                 "store.kafka.keys": True,
-                "retention.ms": -1,
+                "receive.buffer.bytes": -1,
                 "topic.tracking.allow.reset": False,
             }
         ).model_dump() == {
@@ -60,7 +60,7 @@ class TestConnectorApiWrapper:
             "max.buffered.records": "500",
             "connection.password": "fake-password",
             "store.kafka.keys": "true",
-            "retention.ms": "-1",
+            "receive.buffer.bytes": "-1",
             "topic.tracking.allow.reset": "false",
         }
 

--- a/tests/component_handlers/topic/test_topic_handler.py
+++ b/tests/component_handlers/topic/test_topic_handler.py
@@ -91,6 +91,28 @@ class TestTopicHandler:
         wrapper.get_broker_config.return_value = BrokerConfigResponse(**broker_response)
         return wrapper
 
+    def test_convert_config_values_to_str(self):
+        assert TopicConfig(
+            partitions_count=1,
+            configs={
+                "retention.ms": -1,
+                "cleanup.policy": "delete",
+                "delete.retention.ms": 123456789,
+            },
+        ).model_dump() == {
+            "configs": {
+                "retention.ms": "-1",
+                "cleanup.policy": "delete",
+                "delete.retention.ms": "123456789",
+            },
+            "key_schema": None,
+            "label": None,
+            "partitions_count": 1,
+            "replication_factor": None,
+            "type": None,
+            "value_schema": None,
+        }
+
     @pytest.mark.asyncio()
     async def test_should_call_create_topic_with_dry_run_false(self):
         wrapper = AsyncMock()

--- a/tests/pipeline/snapshots/test_example/test_generate/atm-fraud/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_example/test_generate/atm-fraud/pipeline.yaml
@@ -405,23 +405,23 @@
       connectorType: sink
     version: 1.0.4
   config:
-    auto.create: true
-    connection.ds.pool.size: 5
+    auto.create: 'true'
+    connection.ds.pool.size: '5'
     connection.password: AppPassword
     connection.url: jdbc:postgresql://postgresql-dev.${NAMESPACE}.svc.cluster.local:5432/app_db
     connection.user: app1
     connector.class: io.confluent.connect.jdbc.JdbcSinkConnector
-    errors.deadletterqueue.context.headers.enable: true
+    errors.deadletterqueue.context.headers.enable: 'true'
     errors.deadletterqueue.topic.name: postgres-request-sink-dead-letters
-    errors.deadletterqueue.topic.replication.factor: 1
+    errors.deadletterqueue.topic.replication.factor: '1'
     errors.tolerance: all
     insert.mode: insert
-    insert.mode.databaselevel: true
+    insert.mode.databaselevel: 'true'
     key.converter: org.apache.kafka.connect.storage.StringConverter
     name: atm-fraud-postgresql-connector
     pk.mode: record_value
     table.name.format: fraud_transactions
-    tasks.max: 1
+    tasks.max: '1'
     topics: atm-fraud-account-linker-topic
     transforms: flatten
     transforms.flatten.type: org.apache.kafka.connect.transforms.Flatten$Value

--- a/tests/pipeline/snapshots/test_example/test_generate/word-count/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_example/test_generate/word-count/pipeline.yaml
@@ -157,9 +157,9 @@
     connector.class: com.github.jcustenborder.kafka.connect.redis.RedisSinkConnector
     key.converter: org.apache.kafka.connect.storage.StringConverter
     name: word-count-redis-sink-connector
-    redis.database: 0
+    redis.database: '0'
     redis.hosts: redis-headless:6379
-    tasks.max: 1
+    tasks.max: '1'
     topics: word-count-word-counter-topic
     value.converter: org.apache.kafka.connect.storage.StringConverter
   name: redis-sink-connector

--- a/tests/utils/test_pydantic.py
+++ b/tests/utils/test_pydantic.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 import pytest
 
-from kpops.utils.pydantic import to_dash, to_dot, to_snake
+from kpops.utils.pydantic import to_dash, to_dot, to_snake, to_str
 
 
 @pytest.mark.parametrize(
@@ -46,3 +48,19 @@ def test_to_snake(input: str, expected: str):
 )
 def test_to_dot(input: str, expected: str):
     assert to_dot(input) == expected
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("foo", "foo"),
+        ("1", "1"),
+        (1, "1"),
+        (-1, "-1"),
+        (1.9, "1.9"),
+        (True, "true"),
+        (False, "false"),
+    ],
+)
+def test_to_str(input: Any, expected: str):
+    assert to_str(input) == expected


### PR DESCRIPTION
Kafka Connect API interprets all config values as strings. Currently, it creates an unnecessary diff during `kpops deploy --dry-run` if the user doesn't specify all connector config values as strings. This is something we can do automatically.

![image](https://github.com/user-attachments/assets/1b5ece70-6451-4cbb-9f6c-15a144747618)
