### PR TITLE
Represent multiline strings using YAML block style

### DIFF
--- a/kpops/manifests/kubernetes.py
+++ b/kpops/manifests/kubernetes.py
@@ -5,7 +5,6 @@ import pydantic
 import yaml
 from pydantic import ConfigDict, Field
 from typing_extensions import override
-from yaml.loader import Loader
 
 from kpops.utils.pydantic import CamelCaseConfigModel, by_alias
 
@@ -58,7 +57,7 @@ class KubernetesManifest(CamelCaseConfigModel):
 
     @classmethod
     def from_yaml(cls, /, content: str) -> Iterator[Self]:
-        manifests: Iterator[dict[str, Any]] = yaml.load_all(content, Loader)
+        manifests: Iterator[dict[str, Any]] = yaml.safe_load_all(content)
         for manifest in manifests:
             yield cls(**manifest)
 

--- a/kpops/utils/yaml.py
+++ b/kpops/utils/yaml.py
@@ -113,6 +113,17 @@ def substitute_in_self(input: dict[str, Any]) -> dict[str, Any]:
     return json.loads(old_str)
 
 
+def multiline_str_representer(
+    representer: yaml.representer.SafeRepresenter, data: Any
+) -> yaml.ScalarNode:
+    if "\n" in data:  # represent multiline strings using block style
+        return representer.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return representer.represent_str(data)
+
+
+yaml.representer.SafeRepresenter.add_representer(str, multiline_str_representer)
+
+
 def print_yaml(
     data: Mapping[str, Any] | str, *, substitution: dict[str, Any] | None = None
 ) -> None:

--- a/kpops/utils/yaml.py
+++ b/kpops/utils/yaml.py
@@ -27,9 +27,8 @@ def generate_hashkey(
 def load_yaml_file(
     file_path: Path, *, substitution: Mapping[str, Any] | None = None
 ) -> dict[str, Any] | list[dict[str, Any]]:
-    with file_path.open() as yaml_file:
-        log.debug(f"Picked up: {file_path.resolve().relative_to(Path.cwd())}")
-        return yaml.load(substitute(yaml_file.read(), substitution), Loader=yaml.Loader)
+    log.debug(f"Picked up: {file_path.resolve().relative_to(Path.cwd())}")
+    return yaml.safe_load(substitute(file_path.read_text(), substitution))
 
 
 def substitute(input: str, substitution: Mapping[str, Any] | None = None) -> str:

--- a/tests/compiler/test_yaml_loading.py
+++ b/tests/compiler/test_yaml_loading.py
@@ -20,7 +20,7 @@ def test_fail_load_yaml():
         load_yaml_file(RESOURCE_PATH / "erroneous-file.yaml")
 
 
-@patch("yaml.load")
+@patch("yaml.safe_load")
 def test_caching_load_yaml(mocked_func):
     load_yaml_file(
         RESOURCE_PATH / "test.yaml",

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
@@ -45,9 +45,13 @@ spec:
 ---
 apiVersion: v1
 data:
-  jmx-kafka-streams-app-prometheus.yml: "jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi\n\
-    lowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\nrules:\n\
-    \  - pattern: \".*\"\n"
+  jmx-kafka-streams-app-prometheus.yml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+      - pattern: ".*"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
@@ -1,11 +1,20 @@
 ---
 apiVersion: v1
 data:
-  log4j2.xml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n    <Appenders>\n\
-    \        <Console name=\"Console\" target=\"SYSTEM_OUT\">\n            <PatternLayout\
-    \ pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n\"/>\n        </Console>\n\
-    \    </Appenders>\n    <Loggers>\n        <Root level=\"info\">\n            <AppenderRef\
-    \ ref=\"Console\"/>\n        </Root>\n    </Loggers>\n</Configuration>\n"
+  log4j2.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration>
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
 kind: ConfigMap
 metadata:
   name: resources-streams-bootstrap-my-producer-app
@@ -97,11 +106,20 @@ spec:
 ---
 apiVersion: v1
 data:
-  log4j2.xml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n    <Appenders>\n\
-    \        <Console name=\"Console\" target=\"SYSTEM_OUT\">\n            <PatternLayout\
-    \ pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n\"/>\n        </Console>\n\
-    \    </Appenders>\n    <Loggers>\n        <Root level=\"info\">\n            <AppenderRef\
-    \ ref=\"Console\"/>\n        </Root>\n    </Loggers>\n</Configuration>\n"
+  log4j2.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration>
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
 kind: ConfigMap
 metadata:
   name: resources-streams-bootstrap-my-streams-app
@@ -109,9 +127,13 @@ metadata:
 ---
 apiVersion: v1
 data:
-  jmx-kafka-streams-app-prometheus.yml: "jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi\n\
-    lowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\nrules:\n\
-    \  - pattern: \".*\"\n"
+  jmx-kafka-streams-app-prometheus.yml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+      - pattern: ".*"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -1,5 +1,10 @@
+from collections.abc import Mapping
+from textwrap import dedent
+from typing import Any
+
 import pytest
 
+from kpops.cli.main import print_yaml
 from kpops.utils.yaml import substitute_nested
 
 
@@ -27,3 +32,40 @@ from kpops.utils.yaml import substitute_nested
 )
 def test_substitute_nested(input: str, substitution: dict[str, str], expected: str):
     assert substitute_nested(input, **substitution) == expected
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_stdout"),
+    [
+        pytest.param(
+            {"foo": "bar"},
+            dedent(
+                """\
+                    ---
+                    foo: bar
+
+                    """
+            ),
+        ),
+        pytest.param(
+            {"foo": "bar\nbaz"},
+            dedent(
+                """\
+                    ---
+                    foo: 'bar
+
+                      baz'
+
+                    """
+            ),
+        ),
+    ],
+)
+def test_print_yaml(
+    capsys: pytest.CaptureFixture[str],
+    data: Mapping[str, Any] | str,
+    expected_stdout: str,
+):
+    print_yaml(data)
+    captured = capsys.readouterr()
+    assert captured.out == expected_stdout

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -52,9 +52,9 @@ def test_substitute_nested(input: str, substitution: dict[str, str], expected: s
             dedent(
                 """\
                     ---
-                    foo: 'bar
-
-                      baz'
+                    foo: |-
+                      bar
+                      baz
 
                     """
             ),

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -69,3 +69,4 @@ def test_print_yaml(
     print_yaml(data)
     captured = capsys.readouterr()
     assert captured.out == expected_stdout
+    assert not captured.err


### PR DESCRIPTION
technically is a breaking change

we should decide which specific YAML block style to use, e.g. `|-` (preserve line breaks, no appended linebreak at the end)