### PR TITLE
Indent sequence items to follow style recommendations

### DIFF
--- a/hooks/gen_docs/gen_docs_components.py
+++ b/hooks/gen_docs/gen_docs_components.py
@@ -185,7 +185,7 @@ def check_for_changes_in_kpops_component_structure() -> bool:
     if kpops_new_structure != kpops_structure:
         (PATH_DOCS_COMPONENTS / "dependencies").mkdir(parents=True, exist_ok=True)
         with PATH_DOCS_KPOPS_STRUCTURE.open("w+") as f:
-            yaml.dump(kpops_new_structure, f)
+            yaml.safe_dump(kpops_new_structure, f)
         PATH_DOCS_COMPONENTS_DEPENDENCIES.unlink(missing_ok=True)
         PATH_DOCS_COMPONENTS_DEPENDENCIES_DEFAULTS.unlink(missing_ok=True)
         if ".gitignore" not in SCRIPT_ARGUMENTS:
@@ -224,9 +224,9 @@ def get_sections(component_name: str, *, exist_changes: bool) -> KpopsComponent:
             component_definition_sections_names,
         )
         with PATH_DOCS_COMPONENTS_DEPENDENCIES.open("a") as f:
-            yaml.dump({component_file_name: component_sections}, f)
+            yaml.safe_dump({component_file_name: component_sections}, f)
         with PATH_DOCS_COMPONENTS_DEPENDENCIES_DEFAULTS.open("a") as f:
-            yaml.dump({component_file_name: component_sections_not_inherited}, f)
+            yaml.safe_dump({component_file_name: component_sections_not_inherited}, f)
     else:
         component_sections: list[str] = PIPELINE_COMPONENT_DEPENDENCIES[  # type: ignore [reportGeneralTypeIssues]
             component_file_name

--- a/kpops/manifests/kubernetes.py
+++ b/kpops/manifests/kubernetes.py
@@ -5,7 +5,6 @@ import pydantic
 import yaml
 from pydantic import ConfigDict, Field
 from typing_extensions import override
-from yaml.loader import Loader
 
 from kpops.utils.pydantic import CamelCaseConfigModel, by_alias
 
@@ -58,7 +57,7 @@ class KubernetesManifest(CamelCaseConfigModel):
 
     @classmethod
     def from_yaml(cls, /, content: str) -> Iterator[Self]:
-        manifests: Iterator[dict[str, Any]] = yaml.load_all(content, Loader)
+        manifests: Iterator[dict[str, Any]] = yaml.safe_load_all(content)
         for manifest in manifests:
             yield cls(**manifest)
 

--- a/kpops/pipeline/__init__.py
+++ b/kpops/pipeline/__init__.py
@@ -21,7 +21,7 @@ from kpops.component_handlers import ComponentHandlers
 from kpops.components.base_components.pipeline_component import PipelineComponent
 from kpops.utils.dict_ops import update_nested_pair
 from kpops.utils.environment import ENV, PIPELINE_PATH
-from kpops.utils.yaml import load_yaml_file
+from kpops.utils.yaml import CustomSafeDumper, load_yaml_file
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Coroutine, Iterator
@@ -97,7 +97,10 @@ class Pipeline(BaseModel):
 
     def to_yaml(self) -> str:
         return yaml.dump(
-            self.model_dump(mode="json", by_alias=True, exclude_none=True)["components"]
+            self.model_dump(mode="json", by_alias=True, exclude_none=True)[
+                "components"
+            ],
+            Dumper=CustomSafeDumper,
         )
 
     def build_execution_graph(

--- a/kpops/utils/dict_differ.py
+++ b/kpops/utils/dict_differ.py
@@ -134,4 +134,4 @@ def colorize_line(line: str) -> str:
 
 
 def to_yaml(data: Mapping) -> Sequence[str]:
-    return yaml.dump(data, sort_keys=True).splitlines(keepends=True)
+    return yaml.safe_dump(data, sort_keys=True).splitlines(keepends=True)

--- a/kpops/utils/yaml.py
+++ b/kpops/utils/yaml.py
@@ -123,6 +123,11 @@ def multiline_str_representer(
 yaml.representer.SafeRepresenter.add_representer(str, multiline_str_representer)
 
 
+class CustomSafeDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, False)
+
+
 def print_yaml(
     data: Mapping[str, Any] | str, *, substitution: dict[str, Any] | None = None
 ) -> None:
@@ -132,7 +137,7 @@ def print_yaml(
     :param substitution: Substitution dictionary, defaults to None
     """
     if not isinstance(data, str):
-        data = yaml.safe_dump(dict(data))
+        data = yaml.dump(dict(data), Dumper=CustomSafeDumper)
         data = f"---\n{data}"
     syntax = Syntax(
         substitute(data, substitution),

--- a/kpops/utils/yaml.py
+++ b/kpops/utils/yaml.py
@@ -113,6 +113,17 @@ def substitute_in_self(input: dict[str, Any]) -> dict[str, Any]:
     return json.loads(old_str)
 
 
+def multiline_str_representer(
+    representer: yaml.representer.SafeRepresenter, data: Any
+) -> yaml.ScalarNode:
+    if "\n" in data:  # represent multiline strings using block style
+        return representer.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return representer.represent_str(data)
+
+
+yaml.representer.SafeRepresenter.add_representer(str, multiline_str_representer)
+
+
 def print_yaml(
     data: Mapping[str, Any] | str, *, substitution: dict[str, Any] | None = None
 ) -> None:

--- a/kpops/utils/yaml.py
+++ b/kpops/utils/yaml.py
@@ -27,9 +27,8 @@ def generate_hashkey(
 def load_yaml_file(
     file_path: Path, *, substitution: Mapping[str, Any] | None = None
 ) -> dict[str, Any] | list[dict[str, Any]]:
-    with file_path.open() as yaml_file:
-        log.debug(f"Picked up: {file_path.resolve().relative_to(Path.cwd())}")
-        return yaml.load(substitute(yaml_file.read(), substitution), Loader=yaml.Loader)
+    log.debug(f"Picked up: {file_path.resolve().relative_to(Path.cwd())}")
+    return yaml.safe_load(substitute(file_path.read_text(), substitution))
 
 
 def substitute(input: str, substitution: Mapping[str, Any] | None = None) -> str:

--- a/tests/compiler/test_yaml_loading.py
+++ b/tests/compiler/test_yaml_loading.py
@@ -20,7 +20,7 @@ def test_fail_load_yaml():
         load_yaml_file(RESOURCE_PATH / "erroneous-file.yaml")
 
 
-@patch("yaml.load")
+@patch("yaml.safe_load")
 def test_caching_load_yaml(mocked_func):
     load_yaml_file(
         RESOURCE_PATH / "test.yaml",

--- a/tests/pipeline/snapshots/test_example/test_generate/atm-fraud/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_example/test_generate/atm-fraud/pipeline.yaml
@@ -155,7 +155,7 @@
         brokers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
         errorTopic: atm-fraud-transaction-joiner-dead-letter-topic
         inputTopics:
-        - atm-fraud-transaction-avro-producer-topic
+          - atm-fraud-transaction-avro-producer-topic
         optimizeLeaveGroupBehavior: false
         outputTopic: atm-fraud-transaction-joiner-topic
         schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/
@@ -199,7 +199,7 @@
       brokers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
       errorTopic: atm-fraud-transaction-joiner-dead-letter-topic
       inputTopics:
-      - atm-fraud-transaction-avro-producer-topic
+        - atm-fraud-transaction-avro-producer-topic
       optimizeLeaveGroupBehavior: false
       outputTopic: atm-fraud-transaction-joiner-topic
       schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/
@@ -235,7 +235,7 @@
         brokers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
         errorTopic: atm-fraud-fraud-detector-dead-letter-topic
         inputTopics:
-        - atm-fraud-transaction-joiner-topic
+          - atm-fraud-transaction-joiner-topic
         optimizeLeaveGroupBehavior: false
         outputTopic: atm-fraud-fraud-detector-topic
         schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/
@@ -279,7 +279,7 @@
       brokers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
       errorTopic: atm-fraud-fraud-detector-dead-letter-topic
       inputTopics:
-      - atm-fraud-transaction-joiner-topic
+        - atm-fraud-transaction-joiner-topic
       optimizeLeaveGroupBehavior: false
       outputTopic: atm-fraud-fraud-detector-topic
       schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/
@@ -316,9 +316,9 @@
         errorTopic: atm-fraud-account-linker-dead-letter-topic
         extraInputTopics:
           accounts:
-          - atm-fraud-account-producer-topic
+            - atm-fraud-account-producer-topic
         inputTopics:
-        - atm-fraud-fraud-detector-topic
+          - atm-fraud-fraud-detector-topic
         optimizeLeaveGroupBehavior: false
         outputTopic: atm-fraud-account-linker-topic
         schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/
@@ -370,9 +370,9 @@
       errorTopic: atm-fraud-account-linker-dead-letter-topic
       extraInputTopics:
         accounts:
-        - atm-fraud-account-producer-topic
+          - atm-fraud-account-producer-topic
       inputTopics:
-      - atm-fraud-fraud-detector-topic
+        - atm-fraud-fraud-detector-topic
       optimizeLeaveGroupBehavior: false
       outputTopic: atm-fraud-account-linker-topic
       schemaRegistryUrl: http://k8kafka-cp-schema-registry.kpops.svc.cluster.local:8081/

--- a/tests/pipeline/snapshots/test_example/test_generate/word-count/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_example/test_generate/word-count/pipeline.yaml
@@ -68,7 +68,7 @@
         bootstrapServers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
         errorTopic: word-count-word-count-app-dead-letter-topic
         inputTopics:
-        - word-count-data-producer-topic
+          - word-count-data-producer-topic
         outputTopic: word-count-word-count-app-topic
       labels:
         pipeline: word-count
@@ -106,7 +106,7 @@
       bootstrapServers: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
       errorTopic: word-count-word-count-app-dead-letter-topic
       inputTopics:
-      - word-count-data-producer-topic
+        - word-count-data-producer-topic
       outputTopic: word-count-word-count-app-topic
     labels:
       pipeline: word-count

--- a/tests/pipeline/snapshots/test_generate/test_default_config/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_default_config/pipeline.yaml
@@ -74,7 +74,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-custom-config-app2-error
         inputTopics:
-        - resources-custom-config-app1
+          - resources-custom-config-app1
         outputTopic: resources-custom-config-app2
         schemaRegistryUrl: http://localhost:8081/
     version: 2.9.0
@@ -114,7 +114,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-custom-config-app2-error
       inputTopics:
-      - resources-custom-config-app1
+        - resources-custom-config-app1
       outputTopic: resources-custom-config-app2
       schemaRegistryUrl: http://localhost:8081/
   version: 2.9.0

--- a/tests/pipeline/snapshots/test_generate/test_inflate_pipeline/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_inflate_pipeline/pipeline.yaml
@@ -89,7 +89,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-inflate-converter-error
         inputTopics:
-        - resources-pipeline-with-inflate-scheduled-producer
+          - resources-pipeline-with-inflate-scheduled-producer
         outputTopic: resources-pipeline-with-inflate-converter
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -145,7 +145,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-inflate-converter-error
       inputTopics:
-      - resources-pipeline-with-inflate-scheduled-producer
+        - resources-pipeline-with-inflate-scheduled-producer
       outputTopic: resources-pipeline-with-inflate-converter
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -171,7 +171,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-pipeline-with-inflate-should-inflate
+          - resources-pipeline-with-inflate-should-inflate
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -189,7 +189,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-inflate-should-inflate-error
         inputTopics:
-        - resources-pipeline-with-inflate-converter
+          - resources-pipeline-with-inflate-converter
         outputTopic: resources-pipeline-with-inflate-should-inflate
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -227,7 +227,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-pipeline-with-inflate-should-inflate
+        - resources-pipeline-with-inflate-should-inflate
     commandLine:
       TYPE: nothing
     image: fake-registry/filter
@@ -245,7 +245,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-inflate-should-inflate-error
       inputTopics:
-      - resources-pipeline-with-inflate-converter
+        - resources-pipeline-with-inflate-converter
       outputTopic: resources-pipeline-with-inflate-should-inflate
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -315,7 +315,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-inflate-should-inflate-inflated-streams-app-error
         inputTopics:
-        - kafka-sink-connector
+          - kafka-sink-connector
         outputTopic: resources-pipeline-with-inflate-should-inflate-should-inflate-inflated-streams-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -351,7 +351,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-inflate-should-inflate-inflated-streams-app-error
       inputTopics:
-      - kafka-sink-connector
+        - kafka-sink-connector
       outputTopic: resources-pipeline-with-inflate-should-inflate-should-inflate-inflated-streams-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_kafka_connect_sink_weave_from_topics/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_kafka_connect_sink_weave_from_topics/pipeline.yaml
@@ -21,7 +21,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-kafka-connect-sink-streams-app-v2-error
         inputTopics:
-        - example-topic
+          - example-topic
         outputTopic: example-output
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -63,7 +63,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-kafka-connect-sink-streams-app-v2-error
       inputTopics:
-      - example-topic
+        - example-topic
       outputTopic: example-output
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_load_pipeline/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_load_pipeline/pipeline.yaml
@@ -89,7 +89,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-first-pipeline-converter-error
         inputTopics:
-        - resources-first-pipeline-scheduled-producer
+          - resources-first-pipeline-scheduled-producer
         outputTopic: resources-first-pipeline-converter
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -145,7 +145,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-first-pipeline-converter-error
       inputTopics:
-      - resources-first-pipeline-scheduled-producer
+        - resources-first-pipeline-scheduled-producer
       outputTopic: resources-first-pipeline-converter
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -171,7 +171,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+          - resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -189,7 +189,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-error
         inputTopics:
-        - resources-first-pipeline-converter
+          - resources-first-pipeline-converter
         outputTopic: resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -227,7 +227,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+        - resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
     commandLine:
       TYPE: nothing
     image: fake-registry/filter
@@ -245,7 +245,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-error
       inputTopics:
-      - resources-first-pipeline-converter
+        - resources-first-pipeline-converter
       outputTopic: resources-first-pipeline-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_load_pipeline_with_folder_path/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_load_pipeline_with_folder_path/pipeline.yaml
@@ -169,7 +169,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+          - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -223,7 +223,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+        - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
     commandLine:
       TYPE: nothing
     image: fake-registry/filter

--- a/tests/pipeline/snapshots/test_generate/test_load_pipeline_with_multiple_pipeline_paths/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_load_pipeline_with_multiple_pipeline_paths/pipeline.yaml
@@ -169,7 +169,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+          - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -223,7 +223,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
+        - resources-pipeline-folders-pipeline-3-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name-a-long-name
     commandLine:
       TYPE: nothing
     image: fake-registry/filter

--- a/tests/pipeline/snapshots/test_generate/test_no_input_topic/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_no_input_topic/pipeline.yaml
@@ -102,7 +102,7 @@
           extra: example-output-extra
           test-output: test-output-extra
         inputTopics:
-        - example-output
+          - example-output
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
   name: app2
@@ -143,7 +143,7 @@
         extra: example-output-extra
         test-output: test-output-extra
       inputTopics:
-      - example-output
+        - example-output
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
 

--- a/tests/pipeline/snapshots/test_generate/test_no_user_defined_components/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_no_user_defined_components/pipeline.yaml
@@ -21,7 +21,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-no-user-defined-components-streams-app-v2-error
         inputTopics:
-        - example-topic
+          - example-topic
         outputTopic: example-output
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -63,7 +63,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-no-user-defined-components-streams-app-v2-error
       inputTopics:
-      - example-topic
+        - example-topic
       outputTopic: example-output
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_pipelines_with_envs/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_pipelines_with_envs/pipeline.yaml
@@ -89,7 +89,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-envs-converter-error
         inputTopics:
-        - resources-pipeline-with-envs-input-producer
+          - resources-pipeline-with-envs-input-producer
         outputTopic: resources-pipeline-with-envs-converter
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -145,7 +145,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-envs-converter-error
       inputTopics:
-      - resources-pipeline-with-envs-input-producer
+        - resources-pipeline-with-envs-input-producer
       outputTopic: resources-pipeline-with-envs-converter
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -171,7 +171,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-pipeline-with-envs-filter
+          - resources-pipeline-with-envs-filter
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -189,7 +189,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-envs-filter-error
         inputTopics:
-        - resources-pipeline-with-envs-converter
+          - resources-pipeline-with-envs-converter
         outputTopic: resources-pipeline-with-envs-filter
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -227,7 +227,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-pipeline-with-envs-filter
+        - resources-pipeline-with-envs-filter
     commandLine:
       TYPE: nothing
     image: fake-registry/filter
@@ -245,7 +245,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-envs-filter-error
       inputTopics:
-      - resources-pipeline-with-envs-converter
+        - resources-pipeline-with-envs-converter
       outputTopic: resources-pipeline-with-envs-filter
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_read_from_component/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_read_from_component/pipeline.yaml
@@ -100,7 +100,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-read-from-component-inflate-step
+          - resources-read-from-component-inflate-step
       image: fake-registry/filter
       imageTag: 2.4.1
       persistence:
@@ -112,7 +112,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-inflate-step-error
         inputTopics:
-        - resources-read-from-component-producer2
+          - resources-read-from-component-producer2
         outputTopic: resources-read-from-component-inflate-step
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -150,7 +150,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-read-from-component-inflate-step
+        - resources-read-from-component-inflate-step
     image: fake-registry/filter
     imageTag: 2.4.1
     persistence:
@@ -162,7 +162,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-inflate-step-error
       inputTopics:
-      - resources-read-from-component-producer2
+        - resources-read-from-component-producer2
       outputTopic: resources-read-from-component-inflate-step
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -232,7 +232,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-inflate-step-inflated-streams-app-error
         inputTopics:
-        - kafka-sink-connector
+          - kafka-sink-connector
         outputTopic: resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -268,7 +268,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-inflate-step-inflated-streams-app-error
       inputTopics:
-      - kafka-sink-connector
+        - kafka-sink-connector
       outputTopic: resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -294,7 +294,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-read-from-component-inflate-step-without-prefix
+          - resources-read-from-component-inflate-step-without-prefix
       image: fake-registry/filter
       imageTag: 2.4.1
       persistence:
@@ -306,7 +306,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-inflate-step-without-prefix-error
         inputTopics:
-        - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
+          - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
         outputTopic: resources-read-from-component-inflate-step-without-prefix
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -344,7 +344,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-read-from-component-inflate-step-without-prefix
+        - resources-read-from-component-inflate-step-without-prefix
     image: fake-registry/filter
     imageTag: 2.4.1
     persistence:
@@ -356,7 +356,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-inflate-step-without-prefix-error
       inputTopics:
-      - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
+        - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
       outputTopic: resources-read-from-component-inflate-step-without-prefix
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -426,7 +426,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-inflate-step-without-prefix-inflated-streams-app-error
         inputTopics:
-        - kafka-sink-connector
+          - kafka-sink-connector
         outputTopic: inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -462,7 +462,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-inflate-step-without-prefix-inflated-streams-app-error
       inputTopics:
-      - kafka-sink-connector
+        - kafka-sink-connector
       outputTopic: inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -488,7 +488,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-consumer1-error
         inputTopics:
-        - resources-read-from-component-producer1
+          - resources-read-from-component-producer1
         outputTopic: resources-read-from-component-consumer1
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -529,7 +529,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-consumer1-error
       inputTopics:
-      - resources-read-from-component-producer1
+        - resources-read-from-component-producer1
       outputTopic: resources-read-from-component-consumer1
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -555,8 +555,8 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-consumer2-error
         inputTopics:
-        - resources-read-from-component-producer1
-        - resources-read-from-component-consumer1
+          - resources-read-from-component-producer1
+          - resources-read-from-component-consumer1
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
   from:
@@ -595,8 +595,8 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-consumer2-error
       inputTopics:
-      - resources-read-from-component-producer1
-      - resources-read-from-component-consumer1
+        - resources-read-from-component-producer1
+        - resources-read-from-component-consumer1
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
 - _cleaner:
@@ -621,8 +621,8 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-consumer3-error
         inputTopics:
-        - resources-read-from-component-producer1
-        - resources-read-from-component-producer2
+          - resources-read-from-component-producer1
+          - resources-read-from-component-producer2
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
   from:
@@ -661,8 +661,8 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-consumer3-error
       inputTopics:
-      - resources-read-from-component-producer1
-      - resources-read-from-component-producer2
+        - resources-read-from-component-producer1
+        - resources-read-from-component-producer2
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
 - _cleaner:
@@ -687,7 +687,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-consumer4-error
         inputTopics:
-        - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
+          - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
   from:
@@ -724,7 +724,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-consumer4-error
       inputTopics:
-      - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
+        - resources-read-from-component-inflate-step-inflate-step-inflated-streams-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
 - _cleaner:
@@ -749,7 +749,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-read-from-component-consumer5-error
         inputTopics:
-        - inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
+          - inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
   from:
@@ -786,7 +786,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-read-from-component-consumer5-error
       inputTopics:
-      - inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
+        - inflate-step-without-prefix-inflate-step-without-prefix-inflated-streams-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
 

--- a/tests/pipeline/snapshots/test_generate/test_streams_bootstrap/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_streams_bootstrap/pipeline.yaml
@@ -14,12 +14,20 @@
         FAKE_ARG: fake-arg-value
       files:
         log4j2.xml:
-          content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n\
-            \    <Appenders>\n        <Console name=\"Console\" target=\"SYSTEM_OUT\"\
-            >\n            <PatternLayout pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36}\
-            \ - %msg%n\"/>\n        </Console>\n    </Appenders>\n    <Loggers>\n\
-            \        <Root level=\"info\">\n            <AppenderRef ref=\"Console\"\
-            />\n        </Root>\n    </Loggers>\n</Configuration>\n"
+          content: |
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration>
+                <Appenders>
+                    <Console name="Console" target="SYSTEM_OUT">
+                        <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+                    </Console>
+                </Appenders>
+                <Loggers>
+                    <Root level="info">
+                        <AppenderRef ref="Console"/>
+                    </Root>
+                </Loggers>
+            </Configuration>
           mountPath: app/resources
       image: my-registry/my-producer-image
       imagePullPolicy: IfNotPresent
@@ -55,12 +63,20 @@
       FAKE_ARG: fake-arg-value
     files:
       log4j2.xml:
-        content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n  \
-          \  <Appenders>\n        <Console name=\"Console\" target=\"SYSTEM_OUT\"\
-          >\n            <PatternLayout pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36}\
-          \ - %msg%n\"/>\n        </Console>\n    </Appenders>\n    <Loggers>\n  \
-          \      <Root level=\"info\">\n            <AppenderRef ref=\"Console\"/>\n\
-          \        </Root>\n    </Loggers>\n</Configuration>\n"
+        content: |
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Configuration>
+              <Appenders>
+                  <Console name="Console" target="SYSTEM_OUT">
+                      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+                  </Console>
+              </Appenders>
+              <Loggers>
+                  <Root level="info">
+                      <AppenderRef ref="Console"/>
+                  </Root>
+              </Loggers>
+          </Configuration>
         mountPath: app/resources
     image: my-registry/my-producer-image
     imagePullPolicy: IfNotPresent
@@ -88,28 +104,36 @@
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: foo
-                operator: Exists
-                values: []
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: bar
-                operator: DoesNotExist
-                values: []
-            weight: 1
+            - preference:
+                matchExpressions:
+                  - key: foo
+                    operator: Exists
+                    values: []
+              weight: 2
+            - preference:
+                matchExpressions:
+                  - key: bar
+                    operator: DoesNotExist
+                    values: []
+              weight: 1
       commandLine:
         CONVERT_XML: true
       files:
         log4j2.xml:
-          content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n\
-            \    <Appenders>\n        <Console name=\"Console\" target=\"SYSTEM_OUT\"\
-            >\n            <PatternLayout pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36}\
-            \ - %msg%n\"/>\n        </Console>\n    </Appenders>\n    <Loggers>\n\
-            \        <Root level=\"info\">\n            <AppenderRef ref=\"Console\"\
-            />\n        </Root>\n    </Loggers>\n</Configuration>\n"
+          content: |
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Configuration>
+                <Appenders>
+                    <Console name="Console" target="SYSTEM_OUT">
+                        <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+                    </Console>
+                </Appenders>
+                <Loggers>
+                    <Root level="info">
+                        <AppenderRef ref="Console"/>
+                    </Root>
+                </Loggers>
+            </Configuration>
           mountPath: app/resources
       image: my-registry/my-streams-app-image
       imagePullPolicy: IfNotPresent
@@ -125,12 +149,12 @@
         errorTopic: resources-streams-bootstrap-my-streams-app-error
         inputPattern: my-input-pattern
         inputTopics:
-        - my-input-topic
+          - my-input-topic
         labeledInputPatterns:
           my-input-topic-labeled-pattern: my-labeled-input-pattern
         labeledInputTopics:
           my-input-topic-label:
-          - my-labeled-input-topic
+            - my-labeled-input-topic
         labeledOutputTopics:
           my-output-topic-label: my-labeled-topic-output
         outputTopic: my-output-topic
@@ -180,28 +204,36 @@
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: foo
-              operator: Exists
-              values: []
-          weight: 2
-        - preference:
-            matchExpressions:
-            - key: bar
-              operator: DoesNotExist
-              values: []
-          weight: 1
+          - preference:
+              matchExpressions:
+                - key: foo
+                  operator: Exists
+                  values: []
+            weight: 2
+          - preference:
+              matchExpressions:
+                - key: bar
+                  operator: DoesNotExist
+                  values: []
+            weight: 1
     commandLine:
       CONVERT_XML: true
     files:
       log4j2.xml:
-        content: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n  \
-          \  <Appenders>\n        <Console name=\"Console\" target=\"SYSTEM_OUT\"\
-          >\n            <PatternLayout pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36}\
-          \ - %msg%n\"/>\n        </Console>\n    </Appenders>\n    <Loggers>\n  \
-          \      <Root level=\"info\">\n            <AppenderRef ref=\"Console\"/>\n\
-          \        </Root>\n    </Loggers>\n</Configuration>\n"
+        content: |
+          <?xml version="1.0" encoding="UTF-8"?>
+          <Configuration>
+              <Appenders>
+                  <Console name="Console" target="SYSTEM_OUT">
+                      <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+                  </Console>
+              </Appenders>
+              <Loggers>
+                  <Root level="info">
+                      <AppenderRef ref="Console"/>
+                  </Root>
+              </Loggers>
+          </Configuration>
         mountPath: app/resources
     image: my-registry/my-streams-app-image
     imagePullPolicy: IfNotPresent
@@ -217,12 +249,12 @@
       errorTopic: resources-streams-bootstrap-my-streams-app-error
       inputPattern: my-input-pattern
       inputTopics:
-      - my-input-topic
+        - my-input-topic
       labeledInputPatterns:
         my-input-topic-labeled-pattern: my-labeled-input-pattern
       labeledInputTopics:
         my-input-topic-label:
-        - my-labeled-input-topic
+          - my-labeled-input-topic
       labeledOutputTopics:
         my-output-topic-label: my-labeled-topic-output
       outputTopic: my-output-topic

--- a/tests/pipeline/snapshots/test_generate/test_substitute_in_component/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_substitute_in_component/pipeline.yaml
@@ -97,7 +97,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-component-type-substitution-converter-error
         inputTopics:
-        - resources-component-type-substitution-scheduled-producer
+          - resources-component-type-substitution-scheduled-producer
         outputTopic: resources-component-type-substitution-converter
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -153,7 +153,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-component-type-substitution-converter-error
       inputTopics:
-      - resources-component-type-substitution-scheduled-producer
+        - resources-component-type-substitution-scheduled-producer
       outputTopic: resources-component-type-substitution-converter
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2
@@ -179,7 +179,7 @@
         offsetResetPolicy: earliest
         pollingInterval: 30
         topics:
-        - resources-component-type-substitution-filter-app
+          - resources-component-type-substitution-filter-app
       commandLine:
         TYPE: nothing
       image: fake-registry/filter
@@ -203,7 +203,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-component-type-substitution-filter-app-error
         inputTopics:
-        - resources-component-type-substitution-converter
+          - resources-component-type-substitution-converter
         outputTopic: resources-component-type-substitution-filter-app
         schemaRegistryUrl: http://localhost:8081/
     version: 2.4.2
@@ -241,7 +241,7 @@
       offsetResetPolicy: earliest
       pollingInterval: 30
       topics:
-      - resources-component-type-substitution-filter-app
+        - resources-component-type-substitution-filter-app
     commandLine:
       TYPE: nothing
     image: fake-registry/filter
@@ -265,7 +265,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-component-type-substitution-filter-app-error
       inputTopics:
-      - resources-component-type-substitution-converter
+        - resources-component-type-substitution-converter
       outputTopic: resources-component-type-substitution-filter-app
       schemaRegistryUrl: http://localhost:8081/
   version: 2.4.2

--- a/tests/pipeline/snapshots/test_generate/test_with_custom_config_with_absolute_defaults_path/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_with_custom_config_with_absolute_defaults_path/pipeline.yaml
@@ -74,7 +74,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: app2-dead-letter-topic
         inputTopics:
-        - app1-test-topic
+          - app1-test-topic
         outputTopic: app2-test-topic
         schemaRegistryUrl: http://localhost:8081/
     version: 2.9.0
@@ -114,7 +114,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: app2-dead-letter-topic
       inputTopics:
-      - app1-test-topic
+        - app1-test-topic
       outputTopic: app2-test-topic
       schemaRegistryUrl: http://localhost:8081/
   version: 2.9.0

--- a/tests/pipeline/snapshots/test_generate/test_with_custom_config_with_relative_defaults_path/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_with_custom_config_with_relative_defaults_path/pipeline.yaml
@@ -74,7 +74,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: app2-dead-letter-topic
         inputTopics:
-        - app1-test-topic
+          - app1-test-topic
         outputTopic: app2-test-topic
         schemaRegistryUrl: http://localhost:8081/
     version: 2.9.0
@@ -114,7 +114,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: app2-dead-letter-topic
       inputTopics:
-      - app1-test-topic
+        - app1-test-topic
       outputTopic: app2-test-topic
       schemaRegistryUrl: http://localhost:8081/
   version: 2.9.0

--- a/tests/pipeline/snapshots/test_generate/test_with_env_defaults/pipeline.yaml
+++ b/tests/pipeline/snapshots/test_generate/test_with_env_defaults/pipeline.yaml
@@ -21,7 +21,7 @@
           large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
         errorTopic: resources-pipeline-with-env-defaults-streams-app-v2-development-error
         inputTopics:
-        - example-topic
+          - example-topic
         outputTopic: example-output
         schemaRegistryUrl: http://localhost:8081/
     version: 2.9.0
@@ -63,7 +63,7 @@
         large.message.id.generator: com.bakdata.kafka.MurmurHashIdGenerator
       errorTopic: resources-pipeline-with-env-defaults-streams-app-v2-development-error
       inputTopics:
-      - example-topic
+        - example-topic
       outputTopic: example-output
       schemaRegistryUrl: http://localhost:8081/
   version: 2.9.0

--- a/tests/pipeline/snapshots/test_manifest/test_deploy_argo_mode/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_deploy_argo_mode/manifest.yaml
@@ -18,29 +18,29 @@ spec:
         release: resources-manifest-pipeline-my-producer-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
 
 ---
@@ -87,31 +87,31 @@ spec:
         release: resources-manifest-pipeline-my-producer-app-clean
     spec:
       containers:
-      - args:
-        - clean
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - clean
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 
@@ -140,44 +140,44 @@ spec:
         release: resources-manifest-pipeline-my-streams-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_VOLATILE_GROUP_INSTANCE_ID
-          value: 'true'
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
-            -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_VOLATILE_GROUP_INSTANCE_ID
+              value: 'true'
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       terminationGracePeriodSeconds: 300
 
 ---
@@ -249,43 +249,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_deploy_manifest_mode/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_deploy_manifest_mode/manifest.yaml
@@ -16,29 +16,29 @@ spec:
         release: resources-manifest-pipeline-my-producer-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
 
 ---
@@ -89,44 +89,44 @@ spec:
         release: resources-manifest-pipeline-my-streams-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_VOLATILE_GROUP_INSTANCE_ID
-          value: 'true'
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
-            -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_VOLATILE_GROUP_INSTANCE_ID
+              value: 'true'
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       terminationGracePeriodSeconds: 300
 
 ---

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_clean_manifest_mode/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_clean_manifest_mode/manifest.yaml
@@ -16,31 +16,31 @@ spec:
         release: resources-manifest-pipeline-my-producer-app-clean
     spec:
       containers:
-      - args:
-        - clean
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - clean
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 
@@ -62,43 +62,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_clean_python_api/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_clean_python_api/manifest.yaml
@@ -16,31 +16,31 @@ spec:
         release: resources-manifest-pipeline-my-producer-app-clean
     spec:
       containers:
-      - args:
-        - clean
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - clean
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 
@@ -62,43 +62,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
@@ -17,29 +17,29 @@ spec:
     spec:
       affinity: null
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BROKERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_DEBUG
-          value: 'false'
-        - name: APP_OUTPUT_TOPIC
-          value: resources-custom-config-app1
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: producerApp:latest
-        imagePullPolicy: Always
-        name: resources-custom-config-app1
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 2G
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BROKERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_DEBUG
+              value: 'false'
+            - name: APP_OUTPUT_TOPIC
+              value: resources-custom-config-app1
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: producerApp:latest
+          imagePullPolicy: Always
+          name: resources-custom-config-app1
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 2G
       restartPolicy: OnFailure
 
 ---
@@ -90,79 +90,79 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - resources-custom-config-app2
-              topologyKey: kubernetes.io/hostname
-            weight: 1
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - resources-custom-config-app2
+                topologyKey: kubernetes.io/hostname
+              weight: 1
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: STREAMS_LARGE_MESSAGE_ID_GENERATOR
-          value: com.bakdata.kafka.MurmurHashIdGenerator
-        - name: KAFKA_JMX_PORT
-          value: '5555'
-        - name: APP_VOLATILE_GROUP_INSTANCE_ID
-          value: 'true'
-        - name: APP_BROKERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_DEBUG
-          value: 'false'
-        - name: APP_INPUT_TOPICS
-          value: resources-custom-config-app1
-        - name: APP_OUTPUT_TOPIC
-          value: resources-custom-config-app2
-        - name: APP_ERROR_TOPIC
-          value: resources-custom-config-app2-error
-        - name: JAVA_TOOL_OPTIONS
-          value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
-            -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
-        image: some-image:latest
-        imagePullPolicy: Always
-        name: resources-custom-config-app2
-        ports:
-        - containerPort: 5555
-          name: jmx
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
-      - command:
-        - java
-        - -XX:+UnlockExperimentalVMOptions
-        - -XX:+UseCGroupMemoryLimitForHeap
-        - -XX:MaxRAMFraction=1
-        - -XshowSettings:vm
-        - -jar
-        - jmx_prometheus_httpserver.jar
-        - '5556'
-        - /etc/jmx-streams-app/jmx-kafka-streams-app-prometheus.yml
-        image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
-        name: prometheus-jmx-exporter
-        ports:
-        - containerPort: 5556
-        resources:
-          limits:
-            cpu: 300m
-            memory: 2G
-          requests:
-            cpu: 100m
-            memory: 500Mi
-        volumeMounts:
-        - mountPath: /etc/jmx-streams-app
-          name: jmx-config
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: STREAMS_LARGE_MESSAGE_ID_GENERATOR
+              value: com.bakdata.kafka.MurmurHashIdGenerator
+            - name: KAFKA_JMX_PORT
+              value: '5555'
+            - name: APP_VOLATILE_GROUP_INSTANCE_ID
+              value: 'true'
+            - name: APP_BROKERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_DEBUG
+              value: 'false'
+            - name: APP_INPUT_TOPICS
+              value: resources-custom-config-app1
+            - name: APP_OUTPUT_TOPIC
+              value: resources-custom-config-app2
+            - name: APP_ERROR_TOPIC
+              value: resources-custom-config-app2-error
+            - name: JAVA_TOOL_OPTIONS
+              value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
+          image: some-image:latest
+          imagePullPolicy: Always
+          name: resources-custom-config-app2
+          ports:
+            - containerPort: 5555
+              name: jmx
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
+        - command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - '5556'
+            - /etc/jmx-streams-app/jmx-kafka-streams-app-prometheus.yml
+          image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+          name: prometheus-jmx-exporter
+          ports:
+            - containerPort: 5556
+          resources:
+            limits:
+              cpu: 300m
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 500Mi
+          volumeMounts:
+            - mountPath: /etc/jmx-streams-app
+              name: jmx-config
       volumes:
-      - configMap:
-          name: resources-custom-config-app2-jmx-configmap
-        name: jmx-config
+        - configMap:
+            name: resources-custom-config-app2-jmx-configmap
+          name: jmx-config
 

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_command/manifest.yaml
@@ -45,9 +45,13 @@ spec:
 ---
 apiVersion: v1
 data:
-  jmx-kafka-streams-app-prometheus.yml: "jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi\n\
-    lowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\nrules:\n\
-    \  - pattern: \".*\"\n"
+  jmx-kafka-streams-app-prometheus.yml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+      - pattern: ".*"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_deploy_python_api/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_deploy_python_api/manifest.yaml
@@ -16,29 +16,29 @@ spec:
         release: resources-manifest-pipeline-my-producer-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_OUTPUT_TOPIC
-          value: my-producer-app-output-topic
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-producer-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-producer-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_OUTPUT_TOPIC
+              value: my-producer-app-output-topic
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-producer-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-producer-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
 
 ---
@@ -89,44 +89,44 @@ spec:
         release: resources-manifest-pipeline-my-streams-app
     spec:
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_VOLATILE_GROUP_INSTANCE_ID
-          value: 'true'
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
-            -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_VOLATILE_GROUP_INSTANCE_ID
+              value: 'true'
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       terminationGracePeriodSeconds: 300
 
 ---

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_reset_argo_mode/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_reset_argo_mode/manifest.yaml
@@ -40,43 +40,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_reset_manifest_mode/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_reset_manifest_mode/manifest.yaml
@@ -40,43 +40,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_manifest_reset_python_api/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_manifest_reset_python_api/manifest.yaml
@@ -40,43 +40,43 @@ spec:
         release: resources-manifest-pipeline-my-streams-app-clean
     spec:
       containers:
-      - args:
-        - reset
-        env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-manifest-pipeline-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: JAVA_TOOL_OPTIONS
-          value: '-XX:MaxRAMPercentage=75.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: Always
-        name: resources-manifest-pipeline-my-streams-app-clean
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
+        - args:
+            - reset
+          env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-manifest-pipeline-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: JAVA_TOOL_OPTIONS
+              value: '-XX:MaxRAMPercentage=75.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: Always
+          name: resources-manifest-pipeline-my-streams-app-clean
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 30
 

--- a/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
@@ -1,11 +1,20 @@
 ---
 apiVersion: v1
 data:
-  log4j2.xml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n    <Appenders>\n\
-    \        <Console name=\"Console\" target=\"SYSTEM_OUT\">\n            <PatternLayout\
-    \ pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n\"/>\n        </Console>\n\
-    \    </Appenders>\n    <Loggers>\n        <Root level=\"info\">\n            <AppenderRef\
-    \ ref=\"Console\"/>\n        </Root>\n    </Loggers>\n</Configuration>\n"
+  log4j2.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration>
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
 kind: ConfigMap
 metadata:
   name: resources-streams-bootstrap-my-producer-app
@@ -97,11 +106,20 @@ spec:
 ---
 apiVersion: v1
 data:
-  log4j2.xml: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Configuration>\n    <Appenders>\n\
-    \        <Console name=\"Console\" target=\"SYSTEM_OUT\">\n            <PatternLayout\
-    \ pattern=\"%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n\"/>\n        </Console>\n\
-    \    </Appenders>\n    <Loggers>\n        <Root level=\"info\">\n            <AppenderRef\
-    \ ref=\"Console\"/>\n        </Root>\n    </Loggers>\n</Configuration>\n"
+  log4j2.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration>
+        <Appenders>
+            <Console name="Console" target="SYSTEM_OUT">
+                <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+            </Console>
+        </Appenders>
+        <Loggers>
+            <Root level="info">
+                <AppenderRef ref="Console"/>
+            </Root>
+        </Loggers>
+    </Configuration>
 kind: ConfigMap
 metadata:
   name: resources-streams-bootstrap-my-streams-app
@@ -109,9 +127,13 @@ metadata:
 ---
 apiVersion: v1
 data:
-  jmx-kafka-streams-app-prometheus.yml: "jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi\n\
-    lowercaseOutputName: true\nlowercaseOutputLabelNames: true\nssl: false\nrules:\n\
-    \  - pattern: \".*\"\n"
+  jmx-kafka-streams-app-prometheus.yml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:5555/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    rules:
+      - pattern: ".*"
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
+++ b/tests/pipeline/snapshots/test_manifest/test_streams_bootstrap/manifest.yaml
@@ -41,40 +41,40 @@ spec:
             release: resources-streams-bootstrap-my-producer-app
         spec:
           containers:
-          - env:
-            - name: ENV_PREFIX
-              value: APP_
-            - name: APP_BOOTSTRAP_SERVERS
-              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-            - name: APP_SCHEMA_REGISTRY_URL
-              value: http://localhost:8081/
-            - name: APP_OUTPUT_TOPIC
-              value: my-producer-app-output-topic
-            - name: APP_LABELED_OUTPUT_TOPICS
-              value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
-            - name: APP_FAKE_ARG
-              value: fake-arg-value
-            - name: JAVA_TOOL_OPTIONS
-              value: '-XX:MaxRAMPercentage=75.0 '
-            image: my-registry/my-producer-image:1.0.0
-            imagePullPolicy: IfNotPresent
-            name: resources-streams-bootstrap-my-producer-app
-            resources:
-              limits:
-                cpu: 500m
-                memory: 2G
-              requests:
-                cpu: 200m
-                memory: 300Mi
-            volumeMounts:
-            - mountPath: app/resources/log4j2.xml
-              name: config
-              subPath: log4j2.xml
+            - env:
+                - name: ENV_PREFIX
+                  value: APP_
+                - name: APP_BOOTSTRAP_SERVERS
+                  value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+                - name: APP_SCHEMA_REGISTRY_URL
+                  value: http://localhost:8081/
+                - name: APP_OUTPUT_TOPIC
+                  value: my-producer-app-output-topic
+                - name: APP_LABELED_OUTPUT_TOPICS
+                  value: my-producer-app-output-topic-label=my-labeled-producer-app-topic-output,
+                - name: APP_FAKE_ARG
+                  value: fake-arg-value
+                - name: JAVA_TOOL_OPTIONS
+                  value: '-XX:MaxRAMPercentage=75.0 '
+              image: my-registry/my-producer-image:1.0.0
+              imagePullPolicy: IfNotPresent
+              name: resources-streams-bootstrap-my-producer-app
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 2G
+                requests:
+                  cpu: 200m
+                  memory: 300Mi
+              volumeMounts:
+                - mountPath: app/resources/log4j2.xml
+                  name: config
+                  subPath: log4j2.xml
           restartPolicy: OnFailure
           volumes:
-          - configMap:
-              name: resources-streams-bootstrap-my-producer-app
-            name: config
+            - configMap:
+                name: resources-streams-bootstrap-my-producer-app
+              name: config
   schedule: 30 3/8 * * *
   successfulJobsHistoryLimit: 1
   suspend: false
@@ -173,100 +173,100 @@ spec:
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: foo
-                operator: Exists
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: bar
-                operator: DoesNotExist
-            weight: 1
+            - preference:
+                matchExpressions:
+                  - key: foo
+                    operator: Exists
+              weight: 2
+            - preference:
+                matchExpressions:
+                  - key: bar
+                    operator: DoesNotExist
+              weight: 1
       containers:
-      - env:
-        - name: ENV_PREFIX
-          value: APP_
-        - name: KAFKA_LARGE_MESSAGE_ID_GENERATOR
-          value: com.bakdata.kafka.MurmurHashIdGenerator
-        - name: KAFKA_JMX_PORT
-          value: '5555'
-        - name: APP_VOLATILE_GROUP_INSTANCE_ID
-          value: 'true'
-        - name: APP_BOOTSTRAP_SERVERS
-          value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
-        - name: APP_SCHEMA_REGISTRY_URL
-          value: http://localhost:8081/
-        - name: APP_INPUT_TOPICS
-          value: my-input-topic
-        - name: APP_INPUT_PATTERN
-          value: my-input-pattern
-        - name: APP_OUTPUT_TOPIC
-          value: my-output-topic
-        - name: APP_ERROR_TOPIC
-          value: resources-streams-bootstrap-my-streams-app-error
-        - name: APP_LABELED_OUTPUT_TOPICS
-          value: my-output-topic-label=my-labeled-topic-output,
-        - name: APP_LABELED_INPUT_TOPICS
-          value: my-input-topic-label=my-labeled-input-topic,
-        - name: APP_LABELED_INPUT_PATTERNS
-          value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
-        - name: APP_APPLICATION_ID
-          value: my-streams-app-id
-        - name: APP_CONVERT_XML
-          value: 'true'
-        - name: JAVA_TOOL_OPTIONS
-          value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
-            -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=85.0 '
-        image: my-registry/my-streams-app-image:1.0.0
-        imagePullPolicy: IfNotPresent
-        name: resources-streams-bootstrap-my-streams-app
-        ports:
-        - containerPort: 5555
-          name: jmx
-        resources:
-          limits:
-            cpu: 500m
-            memory: 2G
-          requests:
-            cpu: 200m
-            memory: 300Mi
-        volumeMounts:
-        - mountPath: app/resources/log4j2.xml
-          name: config
-          subPath: log4j2.xml
-      - command:
-        - java
-        - -XX:+UnlockExperimentalVMOptions
-        - -XX:+UseCGroupMemoryLimitForHeap
-        - -XX:MaxRAMFraction=1
-        - -XshowSettings:vm
-        - -jar
-        - jmx_prometheus_httpserver.jar
-        - '5556'
-        - /etc/jmx-streams-app/jmx-kafka-streams-app-prometheus.yml
-        image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
-        name: prometheus-jmx-exporter
-        ports:
-        - containerPort: 5556
-        resources:
-          limits:
-            cpu: 300m
-            memory: 2G
-          requests:
-            cpu: 100m
-            memory: 500Mi
-        volumeMounts:
-        - mountPath: /etc/jmx-streams-app
-          name: jmx-config
+        - env:
+            - name: ENV_PREFIX
+              value: APP_
+            - name: KAFKA_LARGE_MESSAGE_ID_GENERATOR
+              value: com.bakdata.kafka.MurmurHashIdGenerator
+            - name: KAFKA_JMX_PORT
+              value: '5555'
+            - name: APP_VOLATILE_GROUP_INSTANCE_ID
+              value: 'true'
+            - name: APP_BOOTSTRAP_SERVERS
+              value: http://k8kafka-cp-kafka-headless.kpops.svc.cluster.local:9092
+            - name: APP_SCHEMA_REGISTRY_URL
+              value: http://localhost:8081/
+            - name: APP_INPUT_TOPICS
+              value: my-input-topic
+            - name: APP_INPUT_PATTERN
+              value: my-input-pattern
+            - name: APP_OUTPUT_TOPIC
+              value: my-output-topic
+            - name: APP_ERROR_TOPIC
+              value: resources-streams-bootstrap-my-streams-app-error
+            - name: APP_LABELED_OUTPUT_TOPICS
+              value: my-output-topic-label=my-labeled-topic-output,
+            - name: APP_LABELED_INPUT_TOPICS
+              value: my-input-topic-label=my-labeled-input-topic,
+            - name: APP_LABELED_INPUT_PATTERNS
+              value: my-input-topic-labeled-pattern=my-labeled-input-pattern,
+            - name: APP_APPLICATION_ID
+              value: my-streams-app-id
+            - name: APP_CONVERT_XML
+              value: 'true'
+            - name: JAVA_TOOL_OPTIONS
+              value: '-Dcom.sun.management.jmxremote.port=5555 -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false -XX:MaxRAMPercentage=85.0 '
+          image: my-registry/my-streams-app-image:1.0.0
+          imagePullPolicy: IfNotPresent
+          name: resources-streams-bootstrap-my-streams-app
+          ports:
+            - containerPort: 5555
+              name: jmx
+          resources:
+            limits:
+              cpu: 500m
+              memory: 2G
+            requests:
+              cpu: 200m
+              memory: 300Mi
+          volumeMounts:
+            - mountPath: app/resources/log4j2.xml
+              name: config
+              subPath: log4j2.xml
+        - command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - '5556'
+            - /etc/jmx-streams-app/jmx-kafka-streams-app-prometheus.yml
+          image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+          name: prometheus-jmx-exporter
+          ports:
+            - containerPort: 5556
+          resources:
+            limits:
+              cpu: 300m
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 500Mi
+          volumeMounts:
+            - mountPath: /etc/jmx-streams-app
+              name: jmx-config
       terminationGracePeriodSeconds: 300
       volumes:
-      - configMap:
-          name: resources-streams-bootstrap-my-streams-app-jmx-configmap
-        name: jmx-config
-      - configMap:
-          name: resources-streams-bootstrap-my-streams-app
-        name: config
+        - configMap:
+            name: resources-streams-bootstrap-my-streams-app-jmx-configmap
+          name: jmx-config
+        - configMap:
+            name: resources-streams-bootstrap-my-streams-app
+          name: config
 
 ---
 apiVersion: kafka.strimzi.io/v1beta2

--- a/tests/pipeline/test_generate.py
+++ b/tests/pipeline/test_generate.py
@@ -367,7 +367,7 @@ class TestGenerate:
         temp_config_path = RESOURCE_PATH / "custom-config/config_custom.yaml"
         try:
             with temp_config_path.open("w") as abs_config_yaml:
-                yaml.dump(config_dict, abs_config_yaml)
+                yaml.safe_dump(config_dict, abs_config_yaml)
             result = runner.invoke(
                 app,
                 [

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -1,5 +1,10 @@
+from collections.abc import Mapping
+from textwrap import dedent
+from typing import Any
+
 import pytest
 
+from kpops.cli.main import print_yaml
 from kpops.utils.yaml import substitute_nested
 
 
@@ -27,3 +32,40 @@ from kpops.utils.yaml import substitute_nested
 )
 def test_substitute_nested(input: str, substitution: dict[str, str], expected: str):
     assert substitute_nested(input, **substitution) == expected
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_stdout"),
+    [
+        pytest.param(
+            {"foo": "bar"},
+            dedent(
+                """\
+                    ---
+                    foo: bar
+
+                    """
+            ),
+        ),
+        pytest.param(
+            {"foo": "bar\nbaz"},
+            dedent(
+                """\
+                    ---
+                    foo: 'bar
+
+                      baz'
+
+                    """
+            ),
+        ),
+    ],
+)
+def test_print_yaml(
+    capsys: pytest.CaptureFixture[str],
+    data: Mapping[str, Any] | str,
+    expected_stdout: str,
+):
+    print_yaml(data)
+    captured = capsys.readouterr()
+    assert captured.out == expected_stdout

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -52,9 +52,9 @@ def test_substitute_nested(input: str, substitution: dict[str, str], expected: s
             dedent(
                 """\
                     ---
-                    foo: 'bar
-
-                      baz'
+                    foo: |-
+                      bar
+                      baz
 
                     """
             ),

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -69,3 +69,4 @@ def test_print_yaml(
     print_yaml(data)
     captured = capsys.readouterr()
     assert captured.out == expected_stdout
+    assert not captured.err

--- a/tests/utils/test_yaml.py
+++ b/tests/utils/test_yaml.py
@@ -59,6 +59,18 @@ def test_substitute_nested(input: str, substitution: dict[str, str], expected: s
                     """
             ),
         ),
+        pytest.param(
+            {"foo": ["bar", "baz"]},
+            dedent(
+                """\
+                    ---
+                    foo:
+                      - bar
+                      - baz
+
+                    """
+            ),
+        ),
     ],
 )
 def test_print_yaml(


### PR DESCRIPTION
Depends on #574 

not indenting items of a YAML sequence is considered bad style by both linters (such as Ansible) and formatters (such as dprint). Since the produced pipeline.yaml files are user-facing we should apply those style recommendations