### PR TITLE
Improve Pyright matcher

### DIFF
--- a/.github/pyright-matcher.json
+++ b/.github/pyright-matcher.json
@@ -4,12 +4,13 @@
             "owner": "pyright",
             "pattern": [
                 {
-                    "regexp": "^\\s\\s(\\S*\\.py):(\\d+):(\\d+)\\s-\\s(error|warning|information):([\\s\\S]+?)(?=(?:^\\s\\s\\S*\\.py:\\d+:\\d+\\s-\\s(?:error|warning|information):|\\z|\\d+ errors,))",
+                    "regexp": "^\\s\\s(\\S*\\.py):(\\d+):(\\d+)\\s-\\s(error|warning|information):\\s([\\s\\S]+?)\\s\\(([\\s\\S]+?)(?=(?:\\)|\\d+ errors,))",
                     "file": 1,
                     "line": 2,
                     "column": 3,
-                    "code": 4,
-                    "message": 5
+                    "severity": 4,
+                    "message": 5,
+                    "code": 6
                 }
             ]
         }


### PR DESCRIPTION
- fix matching correct severity, previously warnings were flagged as errors
- add new capture group for diagnostic code, such as `reportUnknownMemberType`
- simplify lookahead and handle diagnostic groups for one file. these show an additional title as filepath which could throw the previous regex off
