### PR TITLE
Use Pydantic `model_validate` to avoid Pyright warnings

### DIFF
--- a/tests/component_handlers/kubernetes/model.py
+++ b/tests/component_handlers/kubernetes/model.py
@@ -22,8 +22,8 @@ class TestKubernetesManifest:
                     """
                 ),
                 [
-                    KubernetesManifest(
-                        **{
+                    KubernetesManifest.model_validate(
+                        {
                             "apiVersion": "v1",
                             "kind": "ServiceAccount",
                             "metadata": {"labels": {"foo": "bar"}},

--- a/tests/component_handlers/topic/test_utils.py
+++ b/tests/component_handlers/topic/test_utils.py
@@ -151,8 +151,8 @@ def test_compare_single_config_correctly():
 
 
 def test_get_effective_config():
-    topic_config_response = BrokerConfigResponse(
-        **{
+    topic_config_response = BrokerConfigResponse.model_validate(
+        {
             "kind": "KafkaBrokerConfigList",
             "metadata": {
                 "self": "https://pkc-00000.region.provider.confluent.cloud/kafka/v3/clusters/cluster-1/brokers/-/configs",

--- a/tests/components/streams_bootstrap/test_producer_app.py
+++ b/tests/components/streams_bootstrap/test_producer_app.py
@@ -124,9 +124,9 @@ class TestProducerApp:
         )
 
     def test_output_topics(self):
-        producer_app = ProducerApp(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerApp.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "namespace": "test-namespace",
@@ -366,9 +366,9 @@ class TestProducerApp:
         )
 
     def test_get_output_topics(self):
-        producer_app = ProducerApp(
-            name="my-producer",
-            **{
+        producer_app = ProducerApp.model_validate(
+            {
+                "name": "my-producer",
                 "namespace": "test-namespace",
                 "values": {
                     "image": "producer-app",
@@ -418,9 +418,9 @@ class TestProducerApp:
                 },
             },
         )
-        producer_app = ProducerApp(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerApp.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/producer-app",
@@ -468,9 +468,9 @@ class TestProducerApp:
                 },
             },
         )
-        producer_app = ProducerApp(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerApp.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/producer-app",
@@ -536,9 +536,9 @@ class TestProducerApp:
         )
 
         # user defined model
-        producer_app = ProducerApp(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerApp.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/producer-app",
@@ -586,9 +586,9 @@ class TestProducerApp:
 
     def test_validate_cron_expression(self):
         with pytest.raises(ValidationError):
-            ProducerApp(
-                name=PRODUCER_APP_NAME,
-                **{
+            assert ProducerApp.model_validate(
+                {
+                    "name": PRODUCER_APP_NAME,
                     "namespace": "test-namespace",
                     "values": {
                         "image": "registry/producer-app",

--- a/tests/components/streams_bootstrap/test_streams_app.py
+++ b/tests/components/streams_bootstrap/test_streams_app.py
@@ -62,9 +62,9 @@ class TestStreamsApp:
 
     @pytest.fixture()
     def streams_app(self) -> StreamsApp:
-        return StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        return StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -82,9 +82,9 @@ class TestStreamsApp:
 
     @pytest.fixture()
     def stateful_streams_app(self) -> StreamsApp:
-        return StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        return StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -141,9 +141,9 @@ class TestStreamsApp:
         )
 
     def test_set_topics(self):
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -188,9 +188,9 @@ class TestStreamsApp:
         assert "labeledInputPatterns" in kafka_config
 
     def test_no_empty_input_topic(self):
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -220,9 +220,9 @@ class TestStreamsApp:
         with pytest.raises(
             ValueError, match="Define label only if `type` is `pattern` or `None`"
         ):
-            StreamsApp(
-                name=STREAMS_APP_NAME,
-                **{
+            assert StreamsApp.model_validate(
+                {
+                    "name": STREAMS_APP_NAME,
                     "namespace": "test-namespace",
                     "values": {
                         "kafka": {"bootstrapServers": "fake-broker:9092"},
@@ -242,9 +242,9 @@ class TestStreamsApp:
         with pytest.raises(
             ValueError, match="Define `label` only if `type` is undefined"
         ):
-            StreamsApp(
-                name=STREAMS_APP_NAME,
-                **{
+            assert StreamsApp.model_validate(
+                {
+                    "name": STREAMS_APP_NAME,
                     "namespace": "test-namespace",
                     "values": {
                         "kafka": {"bootstrapServers": "fake-broker:9092"},
@@ -261,9 +261,9 @@ class TestStreamsApp:
             )
 
     def test_set_streams_output_from_to(self):
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -301,9 +301,9 @@ class TestStreamsApp:
         )
 
     def test_weave_inputs_from_prev_component(self):
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -338,9 +338,9 @@ class TestStreamsApp:
         ]
 
     async def test_deploy_order_when_dry_run_is_false(self, mocker: MockerFixture):
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsApp",
@@ -617,9 +617,9 @@ class TestStreamsApp:
                 },
             },
         )
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/streams-app",
@@ -696,9 +696,9 @@ class TestStreamsApp:
                 },
             },
         )
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/streams-app",
@@ -754,9 +754,9 @@ class TestStreamsApp:
         )
 
     async def test_get_input_output_topics(self):
-        streams_app = StreamsApp(
-            name="my-app",
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": "my-app",
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/streams-app",
@@ -985,9 +985,9 @@ class TestStreamsApp:
             },
         )
 
-        streams_app = StreamsApp(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsApp.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/streams-app",

--- a/tests/components/streams_bootstrap/test_streams_bootstrap.py
+++ b/tests/components/streams_bootstrap/test_streams_bootstrap.py
@@ -25,9 +25,9 @@ from kpops.components.streams_bootstrap.model import StreamsBootstrapValues
 @pytest.mark.usefixtures("mock_env")
 class TestStreamsBootstrap:
     def test_default_configs(self):
-        streams_bootstrap = StreamsBootstrap(
-            name="example-name",
-            **{
+        streams_bootstrap = StreamsBootstrap.model_validate(
+            {
+                "name": "example-name",
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsBootstrap",
@@ -46,9 +46,9 @@ class TestStreamsBootstrap:
         assert streams_bootstrap.values.image_tag is None
 
     async def test_should_deploy_streams_bootstrap_app(self, mocker: MockerFixture):
-        streams_bootstrap = StreamsBootstrap(
-            name="example-name",
-            **{
+        streams_bootstrap = StreamsBootstrap.model_validate(
+            {
+                "name": "example-name",
                 "namespace": "test-namespace",
                 "values": {
                     "image": "streamsBootstrap",
@@ -101,8 +101,8 @@ class TestStreamsBootstrap:
                 "1 validation error for StreamsBootstrapValues\nimageTag\n  String should match pattern '^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'"
             ),
         ):
-            StreamsBootstrapValues(
-                **{
+            assert StreamsBootstrapValues.model_validate(
+                {
                     "image": "streamsBootstrap",
                     "imageTag": "invalid image tag!",
                     "kafka": {
@@ -118,9 +118,9 @@ class TestStreamsBootstrap:
                 "When using the streams-bootstrap component your version ('2.1.0') must be at least 3.0.1."
             ),
         ):
-            StreamsBootstrap(
-                name="example-name",
-                **{
+            assert StreamsBootstrap.model_validate(
+                {
+                    "name": "example-name",
                     "namespace": "test-namespace",
                     "values": {
                         "imageTag": "1.0.0",

--- a/tests/components/streams_bootstrap_v2/test_producer_app.py
+++ b/tests/components/streams_bootstrap_v2/test_producer_app.py
@@ -43,9 +43,9 @@ class TestProducerApp:
 
     @pytest.fixture()
     def producer_app(self) -> ProducerAppV2:
-        return ProducerAppV2(
-            name=PRODUCER_APP_NAME,
-            **{
+        return ProducerAppV2.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "version": "2.4.2",
                 "namespace": "test-namespace",
                 "values": {
@@ -87,9 +87,9 @@ class TestProducerApp:
         )
 
     def test_output_topics(self):
-        producer_app = ProducerAppV2(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerAppV2.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "namespace": "test-namespace",
@@ -325,9 +325,9 @@ class TestProducerApp:
         )
 
     def test_get_output_topics(self):
-        producer_app = ProducerAppV2(
-            name="my-producer",
-            **{
+        producer_app = ProducerAppV2.model_validate(
+            {
+                "name": "my-producer",
                 "namespace": "test-namespace",
                 "values": {
                     "namespace": "test-namespace",
@@ -376,9 +376,9 @@ class TestProducerApp:
                 },
             },
         )
-        producer_app = ProducerAppV2(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerAppV2.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "imageTag": "2.2.2",
@@ -425,9 +425,9 @@ class TestProducerApp:
                 },
             },
         )
-        producer_app = ProducerAppV2(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerAppV2.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "imageTag": "2.2.2",
@@ -492,9 +492,9 @@ class TestProducerApp:
         )
 
         # user defined model
-        producer_app = ProducerAppV2(
-            name=PRODUCER_APP_NAME,
-            **{
+        producer_app = ProducerAppV2.model_validate(
+            {
+                "name": PRODUCER_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/producer-app",

--- a/tests/components/streams_bootstrap_v2/test_streams_app.py
+++ b/tests/components/streams_bootstrap_v2/test_streams_app.py
@@ -65,9 +65,9 @@ class TestStreamsApp:
 
     @pytest.fixture()
     def streams_app(self) -> StreamsAppV2:
-        return StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        return StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -84,9 +84,9 @@ class TestStreamsApp:
 
     @pytest.fixture()
     def stateful_streams_app(self) -> StreamsAppV2:
-        return StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        return StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "statefulSet": True,
@@ -175,9 +175,9 @@ class TestStreamsApp:
         )
 
     def test_set_topics(self):
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -221,9 +221,9 @@ class TestStreamsApp:
         assert "extraInputPatterns" in streams_config
 
     def test_no_empty_input_topic(self):
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -252,9 +252,9 @@ class TestStreamsApp:
         with pytest.raises(
             ValueError, match="Define label only if `type` is `pattern` or `None`"
         ):
-            StreamsAppV2(
-                name=STREAMS_APP_NAME,
-                **{
+            assert StreamsAppV2.model_validate(
+                {
+                    "name": STREAMS_APP_NAME,
                     "namespace": "test-namespace",
                     "values": {
                         "streams": {"brokers": "fake-broker:9092"},
@@ -274,9 +274,9 @@ class TestStreamsApp:
         with pytest.raises(
             ValueError, match="Define `label` only if `type` is undefined"
         ):
-            StreamsAppV2(
-                name=STREAMS_APP_NAME,
-                **{
+            assert StreamsAppV2.model_validate(
+                {
+                    "name": STREAMS_APP_NAME,
                     "namespace": "test-namespace",
                     "values": {
                         "streams": {"brokers": "fake-broker:9092"},
@@ -293,9 +293,9 @@ class TestStreamsApp:
             )
 
     def test_set_streams_output_from_to(self):
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -332,9 +332,9 @@ class TestStreamsApp:
         )
 
     def test_weave_inputs_from_prev_component(self):
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -368,9 +368,9 @@ class TestStreamsApp:
         ]
 
     async def test_deploy_order_when_dry_run_is_false(self, mocker: MockerFixture):
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -643,9 +643,9 @@ class TestStreamsApp:
                 },
             },
         )
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "imageTag": "2.2.2",
@@ -721,9 +721,9 @@ class TestStreamsApp:
                 },
             },
         )
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "imageTag": "2.2.2",
@@ -778,9 +778,9 @@ class TestStreamsApp:
         )
 
     async def test_get_input_output_topics(self):
-        streams_app = StreamsAppV2(
-            name="my-app",
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": "my-app",
                 "namespace": "test-namespace",
                 "values": {
                     "streams": {"brokers": "fake-broker:9092"},
@@ -1020,9 +1020,9 @@ class TestStreamsApp:
             },
         )
 
-        streams_app = StreamsAppV2(
-            name=STREAMS_APP_NAME,
-            **{
+        streams_app = StreamsAppV2.model_validate(
+            {
+                "name": STREAMS_APP_NAME,
                 "namespace": "test-namespace",
                 "values": {
                     "image": "registry/streams-app",

--- a/tests/components/test_base_defaults_component.py
+++ b/tests/components/test_base_defaults_component.py
@@ -114,61 +114,61 @@ class TestBaseDefaultsComponent:
         ENV["environment"] = "development"
         component = Child()
 
-        assert (
-            component.name == "fake-child-name"
-        ), "Child default should overwrite parent default"
-        assert component.nice == {
-            "fake-value": "fake"
-        }, "Field introduce by child should be added"
-        assert (
-            component.value == 2.0
-        ), "Environment tmp_defaults should always overwrite"
-        assert (
-            component.another_hard_coded == "another_hard_coded_value"
-        ), "Defaults in code should be kept for childs"
-        assert (
-            component.hard_coded == "hard_coded_value"
-        ), "Defaults in code should be kept for parents"
+        assert component.name == "fake-child-name", (
+            "Child default should overwrite parent default"
+        )
+        assert component.nice == {"fake-value": "fake"}, (
+            "Field introduce by child should be added"
+        )
+        assert component.value == 2.0, (
+            "Environment tmp_defaults should always overwrite"
+        )
+        assert component.another_hard_coded == "another_hard_coded_value", (
+            "Defaults in code should be kept for childs"
+        )
+        assert component.hard_coded == "hard_coded_value", (
+            "Defaults in code should be kept for parents"
+        )
 
     def test_inherit(self):
         component = Child(
             name="name-defined-in-pipeline_parser",
         )
 
-        assert (
-            component.name == "name-defined-in-pipeline_parser"
-        ), "Kwargs should should overwrite all other values"
-        assert component.nice == {
-            "fake-value": "fake"
-        }, "Field introduce by child should be added"
-        assert (
-            component.value == 2.0
-        ), "Environment tmp_defaults should always overwrite"
-        assert (
-            component.another_hard_coded == "another_hard_coded_value"
-        ), "Defaults in code should be kept for childs"
-        assert (
-            component.hard_coded == "hard_coded_value"
-        ), "Defaults in code should be kept for parents"
+        assert component.name == "name-defined-in-pipeline_parser", (
+            "Kwargs should should overwrite all other values"
+        )
+        assert component.nice == {"fake-value": "fake"}, (
+            "Field introduce by child should be added"
+        )
+        assert component.value == 2.0, (
+            "Environment tmp_defaults should always overwrite"
+        )
+        assert component.another_hard_coded == "another_hard_coded_value", (
+            "Defaults in code should be kept for childs"
+        )
+        assert component.hard_coded == "hard_coded_value", (
+            "Defaults in code should be kept for parents"
+        )
 
     def test_multiple_generations(self):
         component = GrandChild()
 
-        assert (
-            component.name == "fake-child-name"
-        ), "Child default should overwrite parent default"
-        assert component.nice == {
-            "fake-value": "fake"
-        }, "Field introduce by child should be added"
-        assert (
-            component.value == 2.0
-        ), "Environment tmp_defaults should always overwrite"
-        assert (
-            component.another_hard_coded == "another_hard_coded_value"
-        ), "Defaults in code should be kept for childs"
-        assert (
-            component.hard_coded == "hard_coded_value"
-        ), "Defaults in code should be kept for parents"
+        assert component.name == "fake-child-name", (
+            "Child default should overwrite parent default"
+        )
+        assert component.nice == {"fake-value": "fake"}, (
+            "Field introduce by child should be added"
+        )
+        assert component.value == 2.0, (
+            "Environment tmp_defaults should always overwrite"
+        )
+        assert component.another_hard_coded == "another_hard_coded_value", (
+            "Defaults in code should be kept for childs"
+        )
+        assert component.hard_coded == "hard_coded_value", (
+            "Defaults in code should be kept for parents"
+        )
         assert component.grand_child == "grand-child-value"
 
     def test_env_var_substitution(self):
@@ -177,14 +177,14 @@ class TestBaseDefaultsComponent:
 
         assert component.name
 
-        assert (
-            Path(component.name) == RESOURCES_PATH
-        ), "Environment variables should be substituted"
+        assert Path(component.name) == RESOURCES_PATH, (
+            "Environment variables should be substituted"
+        )
 
     def test_merge_defaults(self):
-        component = GrandChild(nested=Nested(**{"bar": False}))
+        component = GrandChild(nested=Nested.model_validate({"bar": False}))
         assert isinstance(component.nested, Nested)
-        assert component.nested == Nested(**{"foo": "foo", "bar": False})
+        assert component.nested == Nested.model_validate({"foo": "foo", "bar": False})
 
     @pytest.mark.parametrize(
         ("pipeline_path", "environment", "expected_default_paths"),

--- a/tests/components/test_base_defaults_component.py
+++ b/tests/components/test_base_defaults_component.py
@@ -114,61 +114,61 @@ class TestBaseDefaultsComponent:
         ENV["environment"] = "development"
         component = Child()
 
-        assert component.name == "fake-child-name", (
-            "Child default should overwrite parent default"
-        )
-        assert component.nice == {"fake-value": "fake"}, (
-            "Field introduce by child should be added"
-        )
-        assert component.value == 2.0, (
-            "Environment tmp_defaults should always overwrite"
-        )
-        assert component.another_hard_coded == "another_hard_coded_value", (
-            "Defaults in code should be kept for childs"
-        )
-        assert component.hard_coded == "hard_coded_value", (
-            "Defaults in code should be kept for parents"
-        )
+        assert (
+            component.name == "fake-child-name"
+        ), "Child default should overwrite parent default"
+        assert component.nice == {
+            "fake-value": "fake"
+        }, "Field introduce by child should be added"
+        assert (
+            component.value == 2.0
+        ), "Environment tmp_defaults should always overwrite"
+        assert (
+            component.another_hard_coded == "another_hard_coded_value"
+        ), "Defaults in code should be kept for childs"
+        assert (
+            component.hard_coded == "hard_coded_value"
+        ), "Defaults in code should be kept for parents"
 
     def test_inherit(self):
         component = Child(
             name="name-defined-in-pipeline_parser",
         )
 
-        assert component.name == "name-defined-in-pipeline_parser", (
-            "Kwargs should should overwrite all other values"
-        )
-        assert component.nice == {"fake-value": "fake"}, (
-            "Field introduce by child should be added"
-        )
-        assert component.value == 2.0, (
-            "Environment tmp_defaults should always overwrite"
-        )
-        assert component.another_hard_coded == "another_hard_coded_value", (
-            "Defaults in code should be kept for childs"
-        )
-        assert component.hard_coded == "hard_coded_value", (
-            "Defaults in code should be kept for parents"
-        )
+        assert (
+            component.name == "name-defined-in-pipeline_parser"
+        ), "Kwargs should should overwrite all other values"
+        assert component.nice == {
+            "fake-value": "fake"
+        }, "Field introduce by child should be added"
+        assert (
+            component.value == 2.0
+        ), "Environment tmp_defaults should always overwrite"
+        assert (
+            component.another_hard_coded == "another_hard_coded_value"
+        ), "Defaults in code should be kept for childs"
+        assert (
+            component.hard_coded == "hard_coded_value"
+        ), "Defaults in code should be kept for parents"
 
     def test_multiple_generations(self):
         component = GrandChild()
 
-        assert component.name == "fake-child-name", (
-            "Child default should overwrite parent default"
-        )
-        assert component.nice == {"fake-value": "fake"}, (
-            "Field introduce by child should be added"
-        )
-        assert component.value == 2.0, (
-            "Environment tmp_defaults should always overwrite"
-        )
-        assert component.another_hard_coded == "another_hard_coded_value", (
-            "Defaults in code should be kept for childs"
-        )
-        assert component.hard_coded == "hard_coded_value", (
-            "Defaults in code should be kept for parents"
-        )
+        assert (
+            component.name == "fake-child-name"
+        ), "Child default should overwrite parent default"
+        assert component.nice == {
+            "fake-value": "fake"
+        }, "Field introduce by child should be added"
+        assert (
+            component.value == 2.0
+        ), "Environment tmp_defaults should always overwrite"
+        assert (
+            component.another_hard_coded == "another_hard_coded_value"
+        ), "Defaults in code should be kept for childs"
+        assert (
+            component.hard_coded == "hard_coded_value"
+        ), "Defaults in code should be kept for parents"
         assert component.grand_child == "grand-child-value"
 
     def test_env_var_substitution(self):
@@ -177,9 +177,9 @@ class TestBaseDefaultsComponent:
 
         assert component.name
 
-        assert Path(component.name) == RESOURCES_PATH, (
-            "Environment variables should be substituted"
-        )
+        assert (
+            Path(component.name) == RESOURCES_PATH
+        ), "Environment variables should be substituted"
 
     def test_merge_defaults(self):
         component = GrandChild(nested=Nested.model_validate({"bar": False}))

--- a/tests/components/test_helm_app.py
+++ b/tests/components/test_helm_app.py
@@ -29,7 +29,7 @@ class TestHelmApp:
 
     @pytest.fixture()
     def app_values(self) -> HelmAppValues:
-        return HelmAppValues(**{"foo": "test-value"})
+        return HelmAppValues.model_validate({"foo": "test-value"})
 
     @pytest.fixture()
     def repo_config(self) -> HelmRepoConfig:

--- a/tests/components/test_kafka_sink_connector.py
+++ b/tests/components/test_kafka_sink_connector.py
@@ -99,8 +99,11 @@ class TestKafkaSinkConnector(TestKafkaConnector):
         topic_pattern = ".*"
         connector = KafkaSinkConnector(
             name=CONNECTOR_NAME,
-            config=KafkaConnectorConfig(
-                **{**connector_config.model_dump(), "topics.regex": topic_pattern}
+            config=KafkaConnectorConfig.model_validate(
+                {
+                    **connector_config.model_dump(),
+                    "topics.regex": topic_pattern,
+                }
             ),
             resetter_namespace=RESETTER_NAMESPACE,
         )


### PR DESCRIPTION
Pyright is trying to be smart and evaluates inputs when using dict unpacking syntax during Pydantic model instantiation. This will obviously cause issues because of the enrichment strategy for KPOps components. It's especially undesired in tests where we deliberately omit certain attributes....