### PR TITLE
ci: run lint job only for target Python version on Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,18 +23,11 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-          - windows-2022
-        python-version: ["3.11", "3.12"]
-        is-draft-pr:
-          - ${{ github.event.pull_request.draft }}
+        python-version: ["3.11"]
         include:
           - python-version: "3.11"
             os: ubuntu-24.04
             format-for-github: true
-        exclude:
-          # skip Windows jobs on draft PRs because they are slow
-          - os: windows-2022
-            is-draft-pr: true
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
atm I don't really see the benefit of repeating lint runs against multiple targets, especially since the Windows runners are so slow (usually ~6x slower than Ubuntu)
we can always reenable those if needed