### PR TITLE
refactor(pydantic): create `SkipGenerate` type

### DIFF
--- a/kpops/components/base_components/helm_app.py
+++ b/kpops/components/base_components/helm_app.py
@@ -5,7 +5,7 @@ from functools import cached_property
 from typing import Annotated, Any
 
 import pydantic
-from pydantic import Field, model_serializer
+from pydantic import Field
 from typing_extensions import override
 
 from kpops.component_handlers.helm_wrapper.dry_run_handler import DryRunHandler
@@ -32,7 +32,7 @@ from kpops.manifests.argo import ArgoSyncWave, enrich_annotations
 from kpops.manifests.kubernetes import K8S_LABEL_MAX_LEN, KubernetesManifest
 from kpops.utils.colorify import magentaify
 from kpops.utils.docstring import describe_attr
-from kpops.utils.pydantic import exclude_by_name
+from kpops.utils.pydantic import SkipGenerate
 
 log = logging.getLogger("HelmApp")
 
@@ -72,11 +72,11 @@ class HelmApp(KubernetesApp):
     :param values: Helm app values
     """
 
-    repo_config: HelmRepoConfig | None = Field(
+    repo_config: SkipGenerate[HelmRepoConfig | None] = Field(
         default=None,
         description=describe_attr("repo_config", __doc__),
     )
-    diff_config: HelmDiffConfig = Field(
+    diff_config: SkipGenerate[HelmDiffConfig] = Field(
         default=HelmDiffConfig(),
         description=describe_attr("diff_config", __doc__),
     )
@@ -214,20 +214,3 @@ class HelmApp(KubernetesApp):
             log.info(f"Helm release {self.helm_release_name} does not exist")
         new_release = Helm.load_manifest(stdout)
         self._helm_diff.log_helm_diff(log, current_release, new_release)
-
-    # TODO: move to PipelineComponent as generic serialize handler for generate context
-    @model_serializer(mode="wrap", when_used="always")
-    def serialize_model(
-        self,
-        default_serialize_handler: pydantic.SerializerFunctionWrapHandler,
-        info: pydantic.SerializationInfo,
-    ) -> dict[str, Any]:
-        # TODO: refactor with Annotated SkipGenerate
-        exclude_generate = {
-            "repo_config",
-            "diff_config",
-        }
-        return exclude_by_name(
-            default_serialize_handler(self),
-            *exclude_generate if info.context == "generate" else {},
-        )

--- a/kpops/components/base_components/kafka_connector.py
+++ b/kpops/components/base_components/kafka_connector.py
@@ -25,7 +25,7 @@ from kpops.components.common.topic import KafkaTopic
 from kpops.config import get_config
 from kpops.utils.colorify import magentaify
 from kpops.utils.docstring import describe_attr
-from kpops.utils.pydantic import CamelCaseConfigModel
+from kpops.utils.pydantic import CamelCaseConfigModel, SkipGenerate
 
 log = logging.getLogger("KafkaConnector")
 
@@ -53,7 +53,7 @@ class KafkaConnectorResetter(Cleaner, ABC):
     from_: None = None  # pyright: ignore[reportIncompatibleVariableOverride]
     to: None = None  # pyright: ignore[reportIncompatibleVariableOverride]
     values: KafkaConnectorResetterValues  # pyright: ignore[reportIncompatibleVariableOverride]
-    repo_config: HelmRepoConfig = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
+    repo_config: SkipGenerate[HelmRepoConfig] = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default=HelmRepoConfig(
             repository_name="bakdata-kafka-connect-resetter",
             url="https://bakdata.github.io/kafka-connect-resetter/",

--- a/kpops/components/base_components/pipeline_component.py
+++ b/kpops/components/base_components/pipeline_component.py
@@ -4,8 +4,7 @@ from abc import ABC
 from collections.abc import Iterator
 from typing import Any, ClassVar
 
-import pydantic
-from pydantic import AliasChoices, ConfigDict, Field, model_serializer
+from pydantic import AliasChoices, ConfigDict, Field
 
 from kpops.components.base_components.base_defaults_component import (
     BaseDefaultsComponent,
@@ -25,10 +24,10 @@ from kpops.components.common.topic import (
 )
 from kpops.manifests.kubernetes import KubernetesManifest
 from kpops.utils.docstring import describe_attr
-from kpops.utils.pydantic import exclude_by_value
+from kpops.utils.pydantic import SerializeAsOptionalModel
 
 
-class PipelineComponent(BaseDefaultsComponent, ABC):
+class PipelineComponent(SerializeAsOptionalModel, BaseDefaultsComponent, ABC):
     """Base class for all components.
 
     :param name: Component name
@@ -278,15 +277,3 @@ class PipelineComponent(BaseDefaultsComponent, ABC):
         :param dry_run: Whether to do a dry run of the command
         """
         await self.destroy(dry_run)
-
-    @model_serializer(mode="wrap", when_used="always")
-    def serialize_model(
-        self,
-        default_serialize_handler: pydantic.SerializerFunctionWrapHandler,
-        info: pydantic.SerializationInfo,
-    ) -> dict[str, Any]:
-        result = default_serialize_handler(self)
-        # HACK: workaround for exclude_none, which is otherwise evaluated too early
-        if info.exclude_none:
-            return exclude_by_value(result, None)
-        return result

--- a/kpops/components/streams_bootstrap/base.py
+++ b/kpops/components/streams_bootstrap/base.py
@@ -18,6 +18,7 @@ from kpops.config import get_config
 from kpops.manifests.kubernetes import KubernetesManifest
 from kpops.manifests.strimzi.kafka_topic import StrimziKafkaTopic
 from kpops.utils.docstring import describe_attr
+from kpops.utils.pydantic import SkipGenerate
 
 if TYPE_CHECKING:
     from kpops.components.streams_bootstrap_v2.base import StreamsBootstrapV2
@@ -46,7 +47,7 @@ class StreamsBootstrap(KafkaApp, HelmApp, ABC):
     values: StreamsBootstrapValues = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
         description=describe_attr("values", __doc__),
     )
-    repo_config: HelmRepoConfig = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
+    repo_config: SkipGenerate[HelmRepoConfig] = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default=STREAMS_BOOTSTRAP_HELM_REPO,
         description=describe_attr("repo_config", __doc__),
     )

--- a/kpops/components/streams_bootstrap_v2/base.py
+++ b/kpops/components/streams_bootstrap_v2/base.py
@@ -19,6 +19,7 @@ from kpops.utils.pydantic import (
     DescConfigModel,
     SerializeAsOptional,
     SerializeAsOptionalModel,
+    SkipGenerate,
     exclude_by_value,
     exclude_defaults,
 )
@@ -135,7 +136,7 @@ class StreamsBootstrapV2(KafkaApp, HelmApp, ABC):
     values: StreamsBootstrapV2Values = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
         description=describe_attr("values", __doc__),
     )
-    repo_config: HelmRepoConfig = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
+    repo_config: SkipGenerate[HelmRepoConfig] = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
         default=STREAMS_BOOTSTRAP_HELM_REPO,
         description=describe_attr("repo_config", __doc__),
     )

--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -12,6 +12,7 @@ from pydantic import (
     GetCoreSchemaHandler,
     SerializationInfo,
     SerializerFunctionWrapHandler,
+    WrapSerializer,
     model_serializer,
 )
 from pydantic.fields import FieldInfo
@@ -299,3 +300,22 @@ class SerializeAsOptionalModel(BaseModel):
         if info.exclude_none:
             return exclude_by_value(result, None)
         return result
+
+
+def serialize_skip_context_generate(
+    value: _T,
+    default_serialize_handler: SerializerFunctionWrapHandler,
+    info: SerializationInfo,
+) -> _T | None:
+    if info.context == "generate":
+        return None  # HACK: serialize to None, then exclude_by_value
+        # instead use Pydantic once supported, custom model_serializer can be removed afterwards
+        # raise PydanticOmit  # depends on https://github.com/pydantic/pydantic/issues/6969
+    return default_serialize_handler(value)
+
+
+SkipGenerate = Annotated[
+    _T,
+    WrapSerializer(serialize_skip_context_generate),
+    "Exclude field from generate output",
+]

--- a/kpops/utils/pydantic.py
+++ b/kpops/utils/pydantic.py
@@ -309,7 +309,7 @@ def serialize_skip_context_generate(
 ) -> _T | None:
     if info.context == "generate":
         return None  # HACK: serialize to None, then exclude_by_value
-        # instead use Pydantic once supported, custom model_serializer can be removed afterwards
+        # instead use PydanticOmit once supported, custom model_serializer can be removed afterwards
         # raise PydanticOmit  # depends on https://github.com/pydantic/pydantic/issues/6969
     return default_serialize_handler(value)
 


### PR DESCRIPTION
can be used to omit specific `PipelineComponent` fields from `kpops generate` output