### PR TITLE
refactor(helm): cache repos and version across components

### DIFF
--- a/kpops/component_handlers/helm_wrapper/helm.py
+++ b/kpops/component_handlers/helm_wrapper/helm.py
@@ -31,12 +31,13 @@ log = logging.getLogger("Helm")
 
 @final
 class Helm:
-    _version: Version = Helm.get_version()
+    _version: Version = None
     _repos: map[str, str] = {}
 
     def __init__(self, helm_config: HelmConfig) -> None:
-        Helm._context = helm_config.context
-        Helm._debug = helm_config.debug
+        Helm._version = Helm.get_version()
+        self._context = helm_config.context
+        self._debug = helm_config.debug
         if Helm._version.major != 3:
             msg = f"The supported Helm version is 3.x.x. The current Helm version is {self._version.major}.{self._version.minor}.{self._version.patch}"
             raise RuntimeError(msg)
@@ -219,12 +220,9 @@ class Helm:
             return ()
 
     @staticmethod
-    def reset_version() -> None:
+    def clear_state_cache() -> None:
         Helm._version = None
-
-    @staticmethod
-    def reset_repos() -> None:
-        Helm._repos = {}
+        Helm._repos = None
 
     @staticmethod
     def get_version() -> Version:

--- a/kpops/component_handlers/helm_wrapper/helm.py
+++ b/kpops/component_handlers/helm_wrapper/helm.py
@@ -31,13 +31,12 @@ log = logging.getLogger("Helm")
 
 @final
 class Helm:
-    _version: Version = None
+    _version: Version = Helm.get_version()
     _repos: map[str, str] = {}
 
     def __init__(self, helm_config: HelmConfig) -> None:
         Helm._context = helm_config.context
         Helm._debug = helm_config.debug
-        Helm._version = Helm.get_version()
         if Helm._version.major != 3:
             msg = f"The supported Helm version is 3.x.x. The current Helm version is {self._version.major}.{self._version.minor}.{self._version.patch}"
             raise RuntimeError(msg)
@@ -218,6 +217,14 @@ class Helm:
             return Helm.load_manifest(stdout)
         except ReleaseNotFoundException:
             return ()
+
+    @staticmethod
+    def reset_version() -> None:
+        Helm._version = None
+
+    @staticmethod
+    def reset_repos() -> None:
+        Helm._repos = {}
 
     @staticmethod
     def get_version() -> Version:

--- a/tests/component_handlers/helm_wrapper/test_helm_wrapper.py
+++ b/tests/component_handlers/helm_wrapper/test_helm_wrapper.py
@@ -117,6 +117,7 @@ class TestHelmWrapper:
     def test_should_include_configured_tls_parameters_on_add_when_version_is_new(
         self, helm: Helm, mock_execute: MagicMock
     ):
+        Helm.clear_state_cache()
         helm.add_repo(
             "test-repository",
             "fake",

--- a/tests/component_handlers/helm_wrapper/test_helm_wrapper.py
+++ b/tests/component_handlers/helm_wrapper/test_helm_wrapper.py
@@ -536,6 +536,7 @@ class TestHelmWrapper:
         expected_version: Version,
     ):
         mock_execute.return_value = raw_version
+        Helm.clear_state_cache()
         helm = Helm(helm_config=HelmConfig())
 
         mock_execute.assert_called_once_with(
@@ -556,6 +557,7 @@ class TestHelmWrapper:
             RuntimeError,
             match="The supported Helm version is 3.x.x. The current Helm version is 2.9.0",
         ):
+            Helm.clear_state_cache()
             Helm(helm_config=HelmConfig())
 
     def test_should_raise_exception_if_helm_version_cannot_be_parsed(
@@ -565,4 +567,5 @@ class TestHelmWrapper:
         with pytest.raises(
             RuntimeError, match="Could not parse the Helm version.\n\nHelm output:\n123"
         ):
+            Helm.clear_state_cache()
             Helm(helm_config=HelmConfig())

--- a/tests/components/streams_bootstrap/test_producer_app.py
+++ b/tests/components/streams_bootstrap/test_producer_app.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from kpops.component_handlers import get_handlers
+from kpops.component_handlers.helm_wrapper.dry_run_handler import DryRunHandler
 from kpops.component_handlers.helm_wrapper.helm import Helm
 from kpops.component_handlers.helm_wrapper.model import HelmUpgradeInstallFlags
 from kpops.component_handlers.helm_wrapper.utils import create_helm_release_name
@@ -159,16 +160,12 @@ class TestProducerApp:
         producer_app: ProducerApp,
         mocker: MockerFixture,
     ):
+        mock = mocker.AsyncMock()
         mock_create_topic = mocker.patch.object(
             get_handlers().topic_handler, "create_topic"
         )
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            producer_app._helm, "upgrade_install"
-        )
-
-        mock = mocker.AsyncMock()
         mock.attach_mock(mock_create_topic, "mock_create_topic")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "mock_helm_upgrade_install")
 
         await producer_app.deploy(dry_run=False)
@@ -210,7 +207,7 @@ class TestProducerApp:
         producer_app: ProducerApp,
         mocker: MockerFixture,
     ):
-        mock_helm_uninstall = mocker.patch.object(producer_app._helm, "uninstall")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
 
         await producer_app.destroy(dry_run=True)
 
@@ -224,77 +221,59 @@ class TestProducerApp:
         empty_helm_get_values: MockerFixture,
         mocker: MockerFixture,
     ):
-        # actual component
-        mock_helm_uninstall_producer_app = mocker.patch.object(
-            producer_app._helm, "uninstall"
-        )
-
-        # cleaner
-        mock_helm_upgrade_install = mocker.patch.object(
-            producer_app._cleaner._helm, "upgrade_install"
-        )
-        mock_helm_uninstall = mocker.patch.object(
-            producer_app._cleaner._helm, "uninstall"
-        )
-        mock_helm_print_helm_diff = mocker.patch.object(
-            producer_app._cleaner._dry_run_handler, "print_helm_diff"
-        )
-
         mock = mocker.MagicMock()
-        mock.attach_mock(
-            mock_helm_uninstall_producer_app, "helm_uninstall_producer_app"
-        )
-        mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "helm_upgrade_install")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
+        mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
+        mock_helm_print_helm_diff = mocker.patch.object(
+            DryRunHandler, "print_helm_diff"
+        )
         mock.attach_mock(mock_helm_print_helm_diff, "print_helm_diff")
 
         await producer_app.clean(dry_run=True)
 
-        mock.assert_has_calls(
-            [
-                mocker.call.helm_uninstall_producer_app(
-                    "test-namespace", PRODUCER_APP_RELEASE_NAME, True
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    True,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_upgrade_install(
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    "bakdata-streams-bootstrap/producer-app-cleanup-job",
-                    True,
-                    "test-namespace",
-                    {
-                        "nameOverride": PRODUCER_APP_CLEAN_HELM_NAMEOVERRIDE,
-                        "image": "ProducerApp",
-                        "kafka": {
-                            "bootstrapServers": "fake-broker:9092",
-                            "outputTopic": "producer-app-output-topic",
-                        },
+        assert mock.mock_calls == [
+            mocker.call.helm_uninstall(
+                "test-namespace", PRODUCER_APP_RELEASE_NAME, True
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                True,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_upgrade_install(
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                "bakdata-streams-bootstrap/producer-app-cleanup-job",
+                True,
+                "test-namespace",
+                {
+                    "nameOverride": PRODUCER_APP_CLEAN_HELM_NAMEOVERRIDE,
+                    "image": "ProducerApp",
+                    "kafka": {
+                        "bootstrapServers": "fake-broker:9092",
+                        "outputTopic": "producer-app-output-topic",
                     },
-                    HelmUpgradeInstallFlags(
-                        version="3.2.1", wait=True, wait_for_jobs=True
-                    ),
-                ),
-                mocker.call.print_helm_diff(
-                    ANY,
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    logging.getLogger("HelmApp"),
-                ),
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    True,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-            ]
-        )
+                },
+                HelmUpgradeInstallFlags(version="3.2.1", wait=True, wait_for_jobs=True),
+            ),
+            mocker.call.print_helm_diff(
+                ANY,
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                logging.getLogger("HelmApp"),
+            ),
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                True,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+        ]
 
     async def test_should_clean_producer_app_and_deploy_clean_up_job_and_delete_clean_up_with_dry_run_false(
         self,
@@ -302,68 +281,50 @@ class TestProducerApp:
         producer_app: ProducerApp,
         empty_helm_get_values: MockerFixture,
     ):
-        # actual component
-        mock_helm_uninstall_producer_app = mocker.patch.object(
-            producer_app._helm, "uninstall"
-        )
-
-        # cleaner
-        mock_helm_upgrade_install = mocker.patch.object(
-            producer_app._cleaner._helm, "upgrade_install"
-        )
-        mock_helm_uninstall = mocker.patch.object(
-            producer_app._cleaner._helm, "uninstall"
-        )
-
         mock = mocker.MagicMock()
-        mock.attach_mock(
-            mock_helm_uninstall_producer_app, "helm_uninstall_producer_app"
-        )
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "helm_upgrade_install")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
         mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
 
         await producer_app.clean(dry_run=False)
 
-        mock.assert_has_calls(
-            [
-                mocker.call.helm_uninstall_producer_app(
-                    "test-namespace", PRODUCER_APP_RELEASE_NAME, False
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    False,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_upgrade_install(
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    "bakdata-streams-bootstrap/producer-app-cleanup-job",
-                    False,
-                    "test-namespace",
-                    {
-                        "nameOverride": PRODUCER_APP_CLEAN_HELM_NAMEOVERRIDE,
-                        "image": "ProducerApp",
-                        "kafka": {
-                            "bootstrapServers": "fake-broker:9092",
-                            "outputTopic": "producer-app-output-topic",
-                        },
+        assert mock.mock_calls == [
+            mocker.call.helm_uninstall(
+                "test-namespace", PRODUCER_APP_RELEASE_NAME, False
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                False,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_upgrade_install(
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                "bakdata-streams-bootstrap/producer-app-cleanup-job",
+                False,
+                "test-namespace",
+                {
+                    "nameOverride": PRODUCER_APP_CLEAN_HELM_NAMEOVERRIDE,
+                    "image": "ProducerApp",
+                    "kafka": {
+                        "bootstrapServers": "fake-broker:9092",
+                        "outputTopic": "producer-app-output-topic",
                     },
-                    HelmUpgradeInstallFlags(
-                        version="3.2.1", wait=True, wait_for_jobs=True
-                    ),
-                ),
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    PRODUCER_APP_CLEAN_RELEASE_NAME,
-                    False,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-            ]
-        )
+                },
+                HelmUpgradeInstallFlags(version="3.2.1", wait=True, wait_for_jobs=True),
+            ),
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                PRODUCER_APP_CLEAN_RELEASE_NAME,
+                False,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+        ]
 
     def test_get_output_topics(self):
         producer_app = ProducerApp.model_validate(
@@ -434,20 +395,16 @@ class TestProducerApp:
                 },
             },
         )
-        uninstall_producer_mock = mocker.patch.object(producer_app._helm, "uninstall")
-        mocker.patch.object(producer_app._cleaner._dry_run_handler, "print_helm_diff")
-        mocker.patch.object(producer_app._cleaner._helm, "uninstall")
-
-        mock_helm_upgrade_install_clean_up = mocker.patch.object(
-            producer_app._cleaner._helm, "upgrade_install"
-        )
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
+        mocker.patch.object(DryRunHandler, "print_helm_diff")
 
         dry_run = True
         await producer_app.reset(dry_run)
-        uninstall_producer_mock.assert_called_once_with(
+        mock_helm_uninstall.assert_called_once_with(
             "test-namespace", PRODUCER_APP_RELEASE_NAME, dry_run
         )
-        mock_helm_upgrade_install_clean_up.assert_not_called()
+        mock_helm_upgrade_install.assert_not_called()
 
     async def test_should_deploy_clean_up_job_with_values_in_cluster_when_clean(
         self, mocker: MockerFixture
@@ -484,13 +441,9 @@ class TestProducerApp:
                 },
             },
         )
-        mocker.patch.object(producer_app._helm, "uninstall")
-        mocker.patch.object(producer_app._cleaner._dry_run_handler, "print_helm_diff")
-        mocker.patch.object(producer_app._cleaner._helm, "uninstall")
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            producer_app._cleaner._helm, "upgrade_install"
-        )
+        mocker.patch.object(Helm, "uninstall")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
+        mocker.patch.object(DryRunHandler, "print_helm_diff")
 
         dry_run = True
         await producer_app.clean(dry_run)
@@ -552,13 +505,9 @@ class TestProducerApp:
                 },
             },
         )
-        mocker.patch.object(producer_app._helm, "uninstall")
-        mocker.patch.object(producer_app._cleaner._dry_run_handler, "print_helm_diff")
-        mocker.patch.object(producer_app._cleaner._helm, "uninstall")
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            producer_app._cleaner._helm, "upgrade_install"
-        )
+        mocker.patch.object(Helm, "uninstall")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
+        mocker.patch.object(DryRunHandler, "print_helm_diff")
 
         dry_run = True
         await producer_app.clean(dry_run)

--- a/tests/components/streams_bootstrap/test_streams_app.py
+++ b/tests/components/streams_bootstrap/test_streams_app.py
@@ -468,68 +468,52 @@ class TestStreamsApp:
         empty_helm_get_values: MockerFixture,
         mocker: MockerFixture,
     ):
-        # actual component
-        mock_helm_uninstall_streams_app = mocker.patch.object(
-            streams_app._helm, "uninstall"
-        )
-
-        cleaner = streams_app._cleaner
-        assert isinstance(cleaner, StreamsAppCleaner)
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            cleaner._helm, "upgrade_install"
-        )
-        mock_helm_uninstall = mocker.patch.object(cleaner._helm, "uninstall")
-
         mock = mocker.MagicMock()
-        mock.attach_mock(
-            mock_helm_uninstall_streams_app, "mock_helm_uninstall_streams_app"
-        )
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "helm_upgrade_install")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
         mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
 
         dry_run = False
         await streams_app.reset(dry_run=dry_run)
 
-        mock.assert_has_calls(
-            [
-                mocker.call.mock_helm_uninstall_streams_app(
-                    "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-                ANY,  # __bool__  # FIXME: why is this in the call stack?
-                ANY,  # __str__
-                mocker.call.helm_upgrade_install(
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    "bakdata-streams-bootstrap/streams-app-cleanup-job",
-                    dry_run,
-                    "test-namespace",
-                    {
-                        "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
-                        "image": "streamsApp",
-                        "kafka": {
-                            "bootstrapServers": "fake-broker:9092",
-                            "outputTopic": "streams-app-output-topic",
-                            "deleteOutput": False,
-                        },
+        assert mock.mock_calls == [
+            mocker.call.helm_uninstall(
+                "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__  # FIXME: why is this in the call stack?
+            ANY,  # __str__
+            mocker.call.helm_upgrade_install(
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                "bakdata-streams-bootstrap/streams-app-cleanup-job",
+                dry_run,
+                "test-namespace",
+                {
+                    "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
+                    "image": "streamsApp",
+                    "kafka": {
+                        "bootstrapServers": "fake-broker:9092",
+                        "outputTopic": "streams-app-output-topic",
+                        "deleteOutput": False,
                     },
-                    HelmUpgradeInstallFlags(
-                        version="3.6.1", wait=True, wait_for_jobs=True
-                    ),
-                ),
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-            ]
-        )
+                },
+                HelmUpgradeInstallFlags(version="3.6.1", wait=True, wait_for_jobs=True),
+            ),
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+        ]
 
     async def test_should_clean_streams_app_and_deploy_clean_up_job_and_delete_clean_up(
         self,
@@ -537,65 +521,52 @@ class TestStreamsApp:
         empty_helm_get_values: MockerFixture,
         mocker: MockerFixture,
     ):
-        # actual component
-        mock_helm_uninstall_streams_app = mocker.patch.object(
-            streams_app._helm, "uninstall"
-        )
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            streams_app._cleaner._helm, "upgrade_install"
-        )
-        mock_helm_uninstall = mocker.patch.object(
-            streams_app._cleaner._helm, "uninstall"
-        )
-
         mock = mocker.MagicMock()
-        mock.attach_mock(mock_helm_uninstall_streams_app, "helm_uninstall_streams_app")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "helm_upgrade_install")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
         mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
 
         dry_run = False
         await streams_app.clean(dry_run=dry_run)
 
-        mock.assert_has_calls(
-            [
-                mocker.call.helm_uninstall_streams_app(
-                    "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_upgrade_install(
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    "bakdata-streams-bootstrap/streams-app-cleanup-job",
-                    dry_run,
-                    "test-namespace",
-                    {
-                        "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
-                        "image": "streamsApp",
-                        "kafka": {
-                            "bootstrapServers": "fake-broker:9092",
-                            "outputTopic": "streams-app-output-topic",
-                            "deleteOutput": True,
-                        },
+        assert mock.mock_calls == [
+            mocker.call.helm_uninstall(
+                "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_upgrade_install(
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                "bakdata-streams-bootstrap/streams-app-cleanup-job",
+                dry_run,
+                "test-namespace",
+                {
+                    "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
+                    "image": "streamsApp",
+                    "kafka": {
+                        "bootstrapServers": "fake-broker:9092",
+                        "outputTopic": "streams-app-output-topic",
+                        "deleteOutput": True,
                     },
-                    HelmUpgradeInstallFlags(
-                        version="3.6.1", wait=True, wait_for_jobs=True
-                    ),
-                ),
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-            ]
-        )
+                },
+                HelmUpgradeInstallFlags(version="3.6.1", wait=True, wait_for_jobs=True),
+            ),
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+        ]
 
     async def test_should_deploy_clean_up_job_with_values_in_cluster_when_reset(
         self, mocker: MockerFixture
@@ -869,73 +840,57 @@ class TestStreamsApp:
         mock_list_pvcs: MagicMock,
         mocker: MockerFixture,
     ):
-        # actual component
-        mock_helm_uninstall_streams_app = mocker.patch.object(
-            stateful_streams_app._helm, "uninstall"
-        )
-        cleaner = stateful_streams_app._cleaner
-        assert isinstance(cleaner, StreamsAppCleaner)
-
-        mock_helm_upgrade_install = mocker.patch.object(
-            cleaner._helm, "upgrade_install"
-        )
-        mock_helm_uninstall = mocker.patch.object(cleaner._helm, "uninstall")
-
-        mock_delete_pvcs = mocker.patch.object(PVCHandler, "delete_pvcs")
-
         mock = MagicMock()
-        mock.attach_mock(mock_helm_uninstall_streams_app, "helm_uninstall_streams_app")
+        mock_helm_upgrade_install = mocker.patch.object(Helm, "upgrade_install")
         mock.attach_mock(mock_helm_upgrade_install, "helm_upgrade_install")
+        mock_helm_uninstall = mocker.patch.object(Helm, "uninstall")
         mock.attach_mock(mock_helm_uninstall, "helm_uninstall")
+        mock_delete_pvcs = mocker.patch.object(PVCHandler, "delete_pvcs")
         mock.attach_mock(mock_delete_pvcs, "delete_pvcs")
 
         dry_run = False
         await stateful_streams_app.clean(dry_run=dry_run)
 
-        mock.assert_has_calls(
-            [
-                mocker.call.helm_uninstall_streams_app(
-                    "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.helm_upgrade_install(
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    "bakdata-streams-bootstrap/streams-app-cleanup-job",
-                    dry_run,
-                    "test-namespace",
-                    {
-                        "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
-                        "image": "streamsApp",
-                        "kafka": {
-                            "bootstrapServers": "fake-broker:9092",
-                            "outputTopic": "streams-app-output-topic",
-                            "deleteOutput": True,
-                        },
-                        "statefulSet": True,
-                        "persistence": {"enabled": True, "size": "5Gi"},
+        assert mock.mock_calls == [
+            mocker.call.helm_uninstall(
+                "test-namespace", STREAMS_APP_RELEASE_NAME, dry_run
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.helm_upgrade_install(
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                "bakdata-streams-bootstrap/streams-app-cleanup-job",
+                dry_run,
+                "test-namespace",
+                {
+                    "nameOverride": STREAMS_APP_CLEAN_HELM_NAME_OVERRIDE,
+                    "image": "streamsApp",
+                    "kafka": {
+                        "bootstrapServers": "fake-broker:9092",
+                        "outputTopic": "streams-app-output-topic",
+                        "deleteOutput": True,
                     },
-                    HelmUpgradeInstallFlags(
-                        version="3.6.1", wait=True, wait_for_jobs=True
-                    ),
-                ),
-                mocker.call.helm_uninstall(
-                    "test-namespace",
-                    STREAMS_APP_CLEAN_RELEASE_NAME,
-                    dry_run,
-                ),
-                ANY,  # __bool__
-                ANY,  # __str__
-                mocker.call.delete_pvcs(False),
-            ]
-        )
+                    "statefulSet": True,
+                    "persistence": {"enabled": True, "size": "5Gi"},
+                },
+                HelmUpgradeInstallFlags(version="3.6.1", wait=True, wait_for_jobs=True),
+            ),
+            mocker.call.helm_uninstall(
+                "test-namespace",
+                STREAMS_APP_CLEAN_RELEASE_NAME,
+                dry_run,
+            ),
+            ANY,  # __bool__
+            ANY,  # __str__
+            mocker.call.delete_pvcs(False),
+        ]
 
     @pytest.mark.usefixtures("kubeconfig")
     async def test_stateful_clean_with_dry_run_true(

--- a/tests/pipeline/test_manifest.py
+++ b/tests/pipeline/test_manifest.py
@@ -32,13 +32,16 @@ class TestManifest:
         return mock_execute
 
     @pytest.fixture()
-    def mock_get_version(self, mocker: MockerFixture) -> MagicMock:
-        mock_get_version = mocker.patch.object(Helm, "get_version")
-        mock_get_version.return_value = Version(major=3, minor=12, patch=0)
-        return mock_get_version
+    def mock_version(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch.object(
+            Helm,
+            "version",
+            return_value=Version(major=3, minor=12, patch=0),
+            new_callable=mocker.PropertyMock,
+        )
 
     @pytest.fixture(autouse=True)
-    def helm(self, mock_get_version: MagicMock) -> Helm:
+    def helm(self, mock_version: MagicMock) -> Helm:
         return Helm(helm_config=HelmConfig())
 
     def test_default_config(self, mock_execute: MagicMock):


### PR DESCRIPTION
In pipelines where there are many `helm` applications, each of them will execute `helm version --short` and if from those, multiple use the same helm repo, it'll run `helm repo add` and `helm repo update` for each of them, this change makes those values static and checks them before executing a `helm` command which is more resource heavy.

> [!WARNING]
> tests are failing but I don't want to invest time if this is not an interesting option, will wait for feedback before fixing.

## description of changes

Add static properties on `Helm` class to re-use already obtained helm outputs instead of executing them each time.
- `helm version --short`
- `helm repo add ...`
- `helm repo update ...`

## evaluation

- Before the version / repository cache was introduce, the test pipeline executed took: 
`poetry run kpops deploy ... >   9.06s user 2.60s system 64% cpu 18.059 total`
- After adding the `helm version` cache, number went down by a little: 
`poetry run kpops deploy ... >   7.70s user 2.19s system 61% cpu 16.175 total`
- After adding repository cache went down even more: 
`poetry run kpops deploy ... >   4.32s user 1.11s system 66% cpu 8.223 total`