### PR TITLE
Fix type errors in the autoscaling model

### DIFF
--- a/kpops/components/streams_bootstrap/common/model.py
+++ b/kpops/components/streams_bootstrap/common/model.py
@@ -165,6 +165,12 @@ class StreamsAppAutoScaling(
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
+    @pydantic.field_serializer("lag_threshold")
+    def serialize_lag_threshold(self, lag_threshold: int | None) -> str | None:
+        if lag_threshold is None:
+            return None
+        return str(lag_threshold)
+
 
 class PersistenceConfig(CamelCaseConfigModel, DescConfigModel):
     """streams-bootstrap persistence configurations.

--- a/kpops/components/streams_bootstrap/common/model.py
+++ b/kpops/components/streams_bootstrap/common/model.py
@@ -165,12 +165,6 @@ class StreamsAppAutoScaling(
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 
-    @pydantic.field_serializer("lag_threshold")
-    def serialize_lag_threshold(self, lag_threshold: int | None) -> str | None:
-        if lag_threshold is None:
-            return None
-        return str(lag_threshold)
-
 
 class PersistenceConfig(CamelCaseConfigModel, DescConfigModel):
     """streams-bootstrap persistence configurations.

--- a/kpops/components/streams_bootstrap/common/model.py
+++ b/kpops/components/streams_bootstrap/common/model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import ClassVar, Self
+from typing import ClassVar, Self, Any
 
 import pydantic
 from pydantic import ConfigDict, Field
@@ -161,7 +161,7 @@ class StreamsAppAutoScaling(
     )
     internal_topics: SerializeAsOptional[list[str]] = []
     topics: SerializeAsOptional[list[str]] = []
-    additional_triggers: SerializeAsOptional[list[str]] = []
+    additional_triggers: SerializeAsOptional[list[dict[str, Any]]] = []
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
 

--- a/tests/components/streams_bootstrap/test_streams_app.py
+++ b/tests/components/streams_bootstrap/test_streams_app.py
@@ -143,6 +143,14 @@ class TestStreamsApp:
             == "${pipeline.name}-test-streams-app-with-lo-c98c5-clean"
         )
 
+    def test_lag_threshold_big_value(self, streams_app: StreamsApp):
+        streams_app.values.autoscaling = StreamsAppAutoScaling(
+            enabled=True,
+            lag_threshold=133713371337,
+        )
+        helm_values = streams_app.to_helm_values()
+        assert helm_values["autoscaling"]["lagThreshold"] == "133713371337"
+
     def test_cleaner_helm_name_override(self, streams_app: StreamsApp):
         assert (
             streams_app._cleaner.to_helm_values()["nameOverride"]

--- a/tests/components/streams_bootstrap/test_streams_app.py
+++ b/tests/components/streams_bootstrap/test_streams_app.py
@@ -137,6 +137,26 @@ class TestStreamsApp:
         )
         assert streams_app._cleaner.values == streams_app.values
 
+    def test_additional_triggers_helm_values(self, streams_app: StreamsApp):
+        additional_triggers = [
+            {
+                "type": "cron",
+                "metadata": {
+                    "timezone": "Asia/Kolkata",
+                    "start": "0 6 * * *",
+                    "end": "0 20 * * *",
+                    "desiredReplicas": "10",
+                },
+            },
+        ]
+        streams_app.values.autoscaling = StreamsAppAutoScaling(
+            enabled=True,
+            lag_threshold=100,
+            additional_triggers=additional_triggers,
+        )
+        helm_values = streams_app.to_helm_values()
+        assert helm_values["autoscaling"]["additionalTriggers"] == additional_triggers
+
     def test_cleaner_helm_release_name(self, streams_app: StreamsApp):
         assert (
             streams_app._cleaner.helm_release_name

--- a/tests/components/streams_bootstrap/test_streams_app.py
+++ b/tests/components/streams_bootstrap/test_streams_app.py
@@ -143,14 +143,6 @@ class TestStreamsApp:
             == "${pipeline.name}-test-streams-app-with-lo-c98c5-clean"
         )
 
-    def test_lag_threshold_big_value(self, streams_app: StreamsApp):
-        streams_app.values.autoscaling = StreamsAppAutoScaling(
-            enabled=True,
-            lag_threshold=133713371337,
-        )
-        helm_values = streams_app.to_helm_values()
-        assert helm_values["autoscaling"]["lagThreshold"] == "133713371337"
-
     def test_cleaner_helm_name_override(self, streams_app: StreamsApp):
         assert (
             streams_app._cleaner.to_helm_values()["nameOverride"]


### PR DESCRIPTION
Fixes #660:

1. Fixes the incorrect type for `additionalTriggers`.
2. Adds a `pydantic.field_serializer` to convert `lagThreshold` to `str`.